### PR TITLE
General: Fix wrong behaviour in SetAudioTracks

### DIFF
--- a/src/WSRequestHandler_Sources.cpp
+++ b/src/WSRequestHandler_Sources.cpp
@@ -350,7 +350,7 @@ RpcResponse WSRequestHandler::SetAudioTracks(const RpcRequest& request)
 
 	if (active && !(mixers & (1 << track)))
 		mixers |= (1 << track);
-	else if (mixers & (1 << track))
+	else if (!active && (mixers & (1 << track)))
 		mixers &= ~(1 << track);
 
 	obs_source_set_audio_mixers(source, mixers);


### PR DESCRIPTION
### Description
When setting an audio track to enabled that was already enabled before
the audio track should now stay enabled instead of being toggled off.

### Motivation and Context
While using obs-websocket in a project I ran into this undocumented behaviour and wanted to PR this easy fix.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Windows 10 Pro (Build 19043)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

Bug fix (non-breaking change which fixes an issue)
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Enhancement (modification to a current event/request which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

