### PR TITLE
Requests: Enable GetRecordDirectory

### DIFF
--- a/src/requesthandler/RequestHandler.cpp
+++ b/src/requesthandler/RequestHandler.cpp
@@ -123,7 +123,7 @@ const std::map<std::string, RequestMethodHandler> RequestHandler::_handlerMap
 	{"ToggleRecordPause", &RequestHandler::ToggleRecordPause},
 	{"PauseRecord", &RequestHandler::PauseRecord},
 	{"ResumeRecord", &RequestHandler::ResumeRecord},
-	//{"GetRecordDirectory", &RequestHandler::GetRecordDirectory},
+	{"GetRecordDirectory", &RequestHandler::GetRecordDirectory},
 
 	// Media Inputs
 	{"GetMediaInputStatus", &RequestHandler::GetMediaInputStatus},

--- a/src/utils/Obs_StringHelper.cpp
+++ b/src/utils/Obs_StringHelper.cpp
@@ -64,12 +64,10 @@ std::string Utils::Obs::StringHelper::GetCurrentProfilePath()
 
 std::string Utils::Obs::StringHelper::GetCurrentRecordOutputPath()
 {
-	//char *recordOutputPath = obs_frontend_get_current_record_output_path();
-	//std::string ret = recordOutputPath;
-	//bfree(recordOutputPath);
-	//return ret;
-
-	return "";
+	char *recordOutputPath = obs_frontend_get_current_record_output_path();
+	std::string ret = recordOutputPath;
+	bfree(recordOutputPath);
+	return ret;
 }
 
 std::string Utils::Obs::StringHelper::GetSourceType(obs_source_t *source)


### PR DESCRIPTION
### Description
Enable the GetRecordDirectory request. Merge when a version of OBS has been released with obsproject/obs-studio/pull/5521

### How Has This Been Tested?
Tested OS(s): Ubuntu 20.04

### Types of changes
- New request/event (non-breaking)
- Documentation change (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

