### PR TITLE
Events: Reenable *Changing events (second time)

### DIFF
--- a/src/eventhandler/EventHandler.cpp
+++ b/src/eventhandler/EventHandler.cpp
@@ -264,18 +264,18 @@ void EventHandler::OnFrontendEvent(enum obs_frontend_event event, void *private_
 			break;
 
 		// Config
-		//case OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING:
-		//	eventHandler->HandleCurrentSceneCollectionChanging();
-		//	break;
+		case OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING:
+			eventHandler->HandleCurrentSceneCollectionChanging();
+			break;
 		case OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED:
 			eventHandler->HandleCurrentSceneCollectionChanged();
 			break;
 		case OBS_FRONTEND_EVENT_SCENE_COLLECTION_LIST_CHANGED:
 			eventHandler->HandleSceneCollectionListChanged();
 			break;
-		//case OBS_FRONTEND_EVENT_PROFILE_CHANGING:
-		//	eventHandler->HandleCurrentProfileChanging();
-		//	break;
+		case OBS_FRONTEND_EVENT_PROFILE_CHANGING:
+			eventHandler->HandleCurrentProfileChanging();
+			break;
 		case OBS_FRONTEND_EVENT_PROFILE_CHANGED:
 			eventHandler->HandleCurrentProfileChanged();
 			break;


### PR DESCRIPTION
### Description
Enables the *Changing events. Merge when a version of OBS has been merged with obsproject/obs-studio/pull/5382

Second PR since I accidentally had to merge the first one.

### How Has This Been Tested?
Tested OS(s): Ubuntu 20.04

### Types of changes
- New request/event (non-breaking
- Documentation change (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

