### PR TITLE
Requests: Enable RemoveInput

### DIFF
--- a/src/requesthandler/RequestHandler.cpp
+++ b/src/requesthandler/RequestHandler.cpp
@@ -67,7 +67,7 @@ const std::map<std::string, RequestMethodHandler> RequestHandler::_handlerMap
 	{"GetInputList", &RequestHandler::GetInputList},
 	{"GetInputKindList", &RequestHandler::GetInputKindList},
 	{"CreateInput", &RequestHandler::CreateInput},
-	//{"RemoveInput", &RequestHandler::RemoveInput}, // Disabled for now. Pending obs-studio#5276
+	{"RemoveInput", &RequestHandler::RemoveInput},
 	{"SetInputName", &RequestHandler::SetInputName},
 	{"GetInputDefaultSettings", &RequestHandler::GetInputDefaultSettings},
 	{"GetInputSettings", &RequestHandler::GetInputSettings},


### PR DESCRIPTION
### Description
Enables the `RemoveInput` request. Merge when a version of OBS is released with obsproject/obs-studio/pull/5276

### How Has This Been Tested?
Tested OS(s): Ubuntu 20.04

### Types of changes
- New request/event (non-breaking)
- Documentation change (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

