### PR TITLE
Base: Remove old ifdefs

### DIFF
--- a/src/obs-websocket.h
+++ b/src/obs-websocket.h
@@ -21,13 +21,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <memory>
 #include <obs.hpp>
-#ifdef _MSC_VER
-    #pragma push_macro("strtoll")
-#endif
 #include <util/platform.h>
-#ifdef _MSC_VER
-    #pragma pop_macro("strtoll")
-#endif
 
 #include "utils/Obs.h"
 #include "plugin-macros.generated.h"


### PR DESCRIPTION
### Description
It was a very cool method to save our precious std::strtoll method, but will no longer be needed on the next OBS release.

### How Has This Been Tested?
Tested OS(s): n/a

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
-   [x] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [x] My code is not on the master branch.
-   [x] The code has been tested.
-   [x] All commit messages are properly formatted and commits squashed where appropriate.
-   [x] I have included updates to all appropriate documentation.

