### PR TITLE
Requests: Add support check for monitoring in `SetInputAudioMonitoringType`

### DIFF
--- a/src/requesthandler/RequestHandler_Inputs.cpp
+++ b/src/requesthandler/RequestHandler_Inputs.cpp
@@ -600,6 +600,9 @@ RequestResult RequestHandler::SetInputAudioMonitorType(const Request& request)
 	if (!(input && request.ValidateString("monitorType", statusCode, comment)))
 		return RequestResult::Error(statusCode, comment);
 
+	if (!obs_audio_monitoring_available())
+		return RequestResult::Error(RequestStatus::InvalidResourceState, "Audio monitoring is not available on this platform.");
+
 	enum obs_monitoring_type monitorType;
 	std::string monitorTypeString = request.RequestData["monitorType"];
 	if (monitorTypeString == "OBS_MONITORING_TYPE_NONE")


### PR DESCRIPTION
### Description
Enables an availability check in the `SetInputAudioMonitorType` request. Merge when a version of OBS is released with obsproject/obs-studio/pull/5225

### How Has This Been Tested?
Tested OS(s): Ubuntu 20.04

### Types of changes
- Other Enhancement (anything not applicable to what is listed)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
