### PR TITLE
docs: fixed wrong opcode in docs

### DIFF
--- a/docs/docs/partials/introduction.md
+++ b/docs/docs/partials/introduction.md
@@ -243,7 +243,7 @@ Authentication is not required
 **Example Message:**
 ```json
 {
-  "op": 2,
+  "op": 5,
   "d": {
     "eventType": "StudioModeStateChanged",
     "eventIntent": 1,


### PR DESCRIPTION
### Description
Fixed incorrect opcode in introduction.md

### Motivation and Context
Documentation fix for wrong opcode

### How Has This Been Tested?
Clicked the link :)

### Types of changes
Documentation change (a change to documentation pages)

### Checklist:
-   [X] I have read the [**contributing** document](https://github.com/Palakis/obs-websocket/blob/4.x-current/CONTRIBUTING.md).
-   [X] My code is not on the master branch.
-   [X] The code has been tested.
-   [X] All commit messages are properly formatted and commits squashed where appropriate.
-   [X] I have included updates to all appropriate documentation.

