### PR TITLE
docs: Fix `Array` type in markdown

### DIFF
--- a/docs/docs/generate_md.py
+++ b/docs/docs/generate_md.py
@@ -178,15 +178,17 @@ def get_requests(requests):
             if request['requestFields']:
                 ret += requestFieldHeader
             for requestField in request['requestFields']:
+                valueType = requestField['valueType'].replace('<', "&lt;").replace('>', "&gt;")
                 valueRestrictions = requestField['valueRestrictions'] if requestField['valueRestrictions'] else 'None'
                 valueOptional = '?' if requestField['valueOptional'] else ''
                 valueOptionalBehavior = requestField['valueOptionalBehavior'] if requestField['valueOptional'] and requestField['valueOptionalBehavior'] else 'N/A'
-                ret += '| {}{} | {} | {} | {} | {} |\n'.format(valueOptional, requestField['valueName'], requestField['valueType'], requestField['valueDescription'], valueRestrictions, valueOptionalBehavior)
+                ret += '| {}{} | {} | {} | {} | {} |\n'.format(valueOptional, requestField['valueName'], valueType, requestField['valueDescription'], valueRestrictions, valueOptionalBehavior)
 
             if request['responseFields']:
                 ret += responseFieldHeader
             for responseField in request['responseFields']:
-                ret += '| {} | {} | {} |\n'.format(responseField['valueName'], responseField['valueType'], responseField['valueDescription'])
+                valueType = responseField['valueType'].replace('<', "&lt;").replace('>', "&gt;")
+                ret += '| {} | {} | {} |\n'.format(responseField['valueName'], valueType, responseField['valueDescription'])
 
             if request != requestsOut[-1]:
                 ret += '\n---\n\n'
@@ -239,7 +241,8 @@ def get_events(events):
             if event['dataFields']:
                 ret += dataFieldHeader
             for dataField in event['dataFields']:
-                ret += '| {} | {} | {} |\n'.format(dataField['valueName'], dataField['valueType'], dataField['valueDescription'])
+                valueType = dataField['valueType'].replace('<', "&lt;").replace('>', "&gt;")
+                ret += '| {} | {} | {} |\n'.format(dataField['valueName'], valueType, dataField['valueDescription'])
 
             if event != eventsOut[-1]:
                 ret += '\n---\n\n'


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Fix the docs generator by replacing `<` with `&lt;` and `>` with `&gt;` for the **Type** column in request and response tables.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The `<` and `>` pair has a special meaning in markdown, being interpreted as HTML tags. That caused the values like `Array<String>` to be displayed as just `Array`. Therefore, they needed to be replaced by their respective `&lt;` and `&gt;` codes.

It is now done for the **Type** column but may need to be extended into other fields that potentially have some form of `<Something>` content.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): MacOS

Ran the `build_docs.sh` script and verified the expected outputs in `protocol.md`.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
