### PR TITLE
docs: Correct the category for scene requests

### DIFF
--- a/src/requesthandler/RequestHandler_Scenes.cpp
+++ b/src/requesthandler/RequestHandler_Scenes.cpp
@@ -31,7 +31,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
  * @rpcVersion -1
  * @initialVersion 5.0.0
  * @api requests
- * @category sources
+ * @category scenes
  */
 RequestResult RequestHandler::GetSceneList(const Request&)
 {
@@ -64,7 +64,7 @@ RequestResult RequestHandler::GetSceneList(const Request&)
  * @rpcVersion -1
  * @initialVersion 5.0.0
  * @api requests
- * @category sources
+ * @category scenes
  */
 RequestResult RequestHandler::GetCurrentProgramScene(const Request&)
 {
@@ -85,7 +85,7 @@ RequestResult RequestHandler::GetCurrentProgramScene(const Request&)
  * @rpcVersion -1
  * @initialVersion 5.0.0
  * @api requests
- * @category sources
+ * @category scenes
  */
 RequestResult RequestHandler::SetCurrentProgramScene(const Request& request)
 {
@@ -112,7 +112,7 @@ RequestResult RequestHandler::SetCurrentProgramScene(const Request& request)
  * @rpcVersion -1
  * @initialVersion 5.0.0
  * @api requests
- * @category sources
+ * @category scenes
  */
 RequestResult RequestHandler::GetCurrentPreviewScene(const Request&)
 {
@@ -139,7 +139,7 @@ RequestResult RequestHandler::GetCurrentPreviewScene(const Request&)
  * @rpcVersion -1
  * @initialVersion 5.0.0
  * @api requests
- * @category sources
+ * @category scenes
  */
 RequestResult RequestHandler::SetCurrentPreviewScene(const Request& request)
 {
@@ -167,7 +167,7 @@ RequestResult RequestHandler::SetCurrentPreviewScene(const Request& request)
  * @rpcVersion -1
  * @initialVersion 5.0.0
  * @api requests
- * @category sources
+ * @category scenes
  */
 RequestResult RequestHandler::CreateScene(const Request& request)
 {
@@ -201,7 +201,7 @@ RequestResult RequestHandler::CreateScene(const Request& request)
  * @rpcVersion -1
  * @initialVersion 5.0.0
  * @api requests
- * @category sources
+ * @category scenes
  */
 RequestResult RequestHandler::RemoveScene(const Request& request)
 {
@@ -230,7 +230,7 @@ RequestResult RequestHandler::RemoveScene(const Request& request)
  * @rpcVersion -1
  * @initialVersion 5.0.0
  * @api requests
- * @category sources
+ * @category scenes
  */
 RequestResult RequestHandler::SetSceneName(const Request& request)
 {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Change the category for all scene related requests to actually be `scenes`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The `@category` annotation for all scene related requests was `sources` instead of `scenes`, thus they ended up in the wrong category in the generated markdown.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 

Adjusted categories and ran `build_docs.sh` to verify the output.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
