### PR TITLE
docs: Add missing `supportedImageFormats` to docs

### DIFF
--- a/src/requesthandler/RequestHandler_General.cpp
+++ b/src/requesthandler/RequestHandler_General.cpp
@@ -29,10 +29,11 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 /**
  * Gets data about the current plugin and RPC version.
  *
- * @responseField obsVersion          | String        | Current OBS Studio version
- * @responseField obsWebSocketVersion | String        | Current obs-websocket version
- * @responseField rpcVersion          | Number        | Current latest obs-websocket RPC version
- * @responseField availableRequests   | Array<String> | Array of available RPC requests for the currently negotiated RPC version
+ * @responseField obsVersion            | String        | Current OBS Studio version
+ * @responseField obsWebSocketVersion   | String        | Current obs-websocket version
+ * @responseField rpcVersion            | Number        | Current latest obs-websocket RPC version
+ * @responseField availableRequests     | Array<String> | Array of available RPC requests for the currently negotiated RPC version
+ * @responseField supportedImageFormats | Array<String> | Image formats available in `GetSourceScreenshot` and `SaveSourceScreenshot` requests.
  *
  * @requestType GetVersion
  * @complexity 1


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Add the `supportedImageFormats` field to the docs of the `GetVersion` request.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The field was simply missing from the docs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
