### PR TITLE
docs: Fix `scenes` type from `String` to `Object`

### DIFF
--- a/src/requesthandler/RequestHandler_Scenes.cpp
+++ b/src/requesthandler/RequestHandler_Scenes.cpp
@@ -22,7 +22,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 /**
  * Gets an array of all scenes in OBS.
  *
- * @responseField scenes                  | Array<String> | Array of scenes in OBS
+ * @responseField scenes                  | Array<Object> | Array of scenes in OBS
  * @responseField currentProgramSceneName | String        | Current program scene
  * @responseField currentPreviewSceneName | String        | Current preview scene. `null` if not in studio mode
  *


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Change the type of the `scenes` field of the `GetSceneList` request from `Array<String>` to ~~`Array<Scene>`~~ `Array<Object>`.

Where or how would you like me to document the fields of the `Scene` object?

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The request returns an array of scene objects but was documented as returning an array of strings instead.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
