### PR TITLE
docs: Document missing `overlay` field

### DIFF
--- a/src/requesthandler/RequestHandler_Inputs.cpp
+++ b/src/requesthandler/RequestHandler_Inputs.cpp
@@ -280,8 +280,7 @@ RequestResult RequestHandler::GetInputSettings(const Request& request)
  *
  * @requestField inputName     | String  | Name of the input to set the settings of
  * @requestField inputSettings | Object  | Object of settings to apply
- * @requestField ?overlay	   | Boolean | True == apply the settings on top of existing ones,
- * 										   False == reset the input to its defaults, then apply settings. | true
+ * @requestField ?overlay      | Boolean | True == apply the settings on top of existing ones, False == reset the input to its defaults, then apply settings. | true
  *
  * @requestType SetInputSettings
  * @complexity 3

--- a/src/requesthandler/RequestHandler_Inputs.cpp
+++ b/src/requesthandler/RequestHandler_Inputs.cpp
@@ -278,8 +278,10 @@ RequestResult RequestHandler::GetInputSettings(const Request& request)
 /**
  * Sets the settings of an input.
  *
- * @requestField inputName     | String | Name of the input to set the settings of
- * @requestField inputSettings | Object | Object of settings to apply
+ * @requestField inputName     | String  | Name of the input to set the settings of
+ * @requestField inputSettings | Object  | Object of settings to apply
+ * @requestField ?overlay	   | Boolean | True == apply the settings on top of existing ones,
+ * 										   False == reset the input to its defaults, then apply settings. | true
  *
  * @requestType SetInputSettings
  * @complexity 3


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Document the missing optional `overlay` field of the `SetInputSettings` request.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The field was already available but not part of the documentation yet.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
