### PR TITLE
protocol: Fix error formatting for wrong op codes

### DIFF
--- a/src/websocketserver/WebSocketServer_Protocol.cpp
+++ b/src/websocketserver/WebSocketServer_Protocol.cpp
@@ -296,7 +296,7 @@ void WebSocketServer::ProcessMessage(SessionPtr session, WebSocketServer::Proces
 			} return;
 		default:
 			ret.closeCode = WebSocketCloseCode::UnknownOpCode;
-			ret.closeReason = std::string("Unknown OpCode: %s") + std::to_string(opCode);
+			ret.closeReason = std::string("Unknown OpCode: ") + std::to_string(opCode);
 			return;
 	}
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Correct the error message returned when an unknown op code was received.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The error message was formatted as `Unknown OpCode: %s5` but should instead be `Unknown OpCode: 5`, removing the `%s`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): MacOS

Verified the `%s` is not part of the message anymore when sending an invalid op code through my `obws` library.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
