### PR TITLE
ci: Set the minimum MacOS version to 10.13

### DIFF
--- a/CI/macos/build-plugin-macos.sh
+++ b/CI/macos/build-plugin-macos.sh
@@ -17,6 +17,7 @@ fi
 echo "[obs-websocket] Building 'obs-websocket' for macOS."
 mkdir -p build && cd build
 cmake .. \
+ 	-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 \
 	-DQTDIR=/tmp/obsdeps \
 	-DLIBOBS_INCLUDE_DIR=../../obs-studio/libobs \
 	-DLIBOBS_LIB=../../obs-studio/libobs \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Sets the `CMAKE_OSX_DEPLOYMENT_TARGET` option to MacOS version `10.13` for MacOS builds (mostly through ci, but technically for anybody who uses the build scripts).

This is the same as done in the main OBS Studio project.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
There have been past reports about obs-websocket not working on older MacOS versions and this setting might eventually fix this. Don't have an old enough Mac to verify this but maybe somebody else who had this issue in the past could try it out?

The seems to be that the CI builds with whatever OS/Xcode version is provided by GitHub and that might have changed between releases in the past. Plus cmake (or rather the Apple clang compiler) seems to use the latest SDK. Therefore, suddenly breaking the builds for older MacOSs due to missing APIs.

Possibly related issues are #849 and #816

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): MacOS

After building locally, verified that the minimum OS version of the binary matches the configured setting.

```sh
$ otool -l build/obs-websocket.so | rg -A3 LC_VERSION
      cmd LC_VERSION_MIN_MACOSX
  cmdsize 16
  version 10.13
      sdk 12.1
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
