### PR TITLE
RequestHandler: Add input open dialog requests

### DIFF
--- a/src/requesthandler/RequestHandler.cpp
+++ b/src/requesthandler/RequestHandler.cpp
@@ -134,6 +134,9 @@ const std::map<std::string, RequestMethodHandler> RequestHandler::_handlerMap
 	// Ui
 	{"GetStudioModeEnabled", &RequestHandler::GetStudioModeEnabled},
 	{"SetStudioModeEnabled", &RequestHandler::SetStudioModeEnabled},
+	{"OpenInputPropertiesDialog", &RequestHandler::OpenInputPropertiesDialog},
+	{"OpenInputFiltersDialog", &RequestHandler::OpenInputFiltersDialog},
+	{"OpenInputInteractDialog", &RequestHandler::OpenInputInteractDialog},
 };
 
 RequestHandler::RequestHandler(SessionPtr session) :

--- a/src/requesthandler/RequestHandler.h
+++ b/src/requesthandler/RequestHandler.h
@@ -156,6 +156,9 @@ class RequestHandler {
 		// Ui
 		RequestResult GetStudioModeEnabled(const Request&);
 		RequestResult SetStudioModeEnabled(const Request&);
+		RequestResult OpenInputPropertiesDialog(const Request&);
+		RequestResult OpenInputFiltersDialog(const Request&);
+		RequestResult OpenInputInteractDialog(const Request&);
 
 		SessionPtr _session;
 		static const std::map<std::string, RequestMethodHandler> _handlerMap;

--- a/src/requesthandler/RequestHandler_Ui.cpp
+++ b/src/requesthandler/RequestHandler_Ui.cpp
@@ -70,3 +70,81 @@ RequestResult RequestHandler::SetStudioModeEnabled(const Request& request)
 
 	return RequestResult::Success();
 }
+
+/**
+ * Opens the properties dialog of an input.
+ *
+ * @requestField inputName | String | Name of the input to open the dialog of
+ *
+ * @requestType OpenInputPropertiesDialog
+ * @complexity 1
+ * @rpcVersion -1
+ * @initialVersion 5.0.0
+ * @category ui
+ * @api requests
+ */
+RequestResult RequestHandler::OpenInputPropertiesDialog(const Request& request)
+{
+	RequestStatus::RequestStatus statusCode;
+	std::string comment;
+	OBSSourceAutoRelease input = request.ValidateInput("inputName", statusCode, comment);
+	if (!input)
+		return RequestResult::Error(statusCode, comment);
+
+	obs_frontend_open_source_properties(input);
+
+	return RequestResult::Success();
+}
+
+/**
+ * Opens the filters dialog of an input.
+ *
+ * @requestField inputName | String | Name of the input to open the dialog of
+ *
+ * @requestType OpenInputFiltersDialog
+ * @complexity 1
+ * @rpcVersion -1
+ * @initialVersion 5.0.0
+ * @category ui
+ * @api requests
+ */
+RequestResult RequestHandler::OpenInputFiltersDialog(const Request& request)
+{
+	RequestStatus::RequestStatus statusCode;
+	std::string comment;
+	OBSSourceAutoRelease input = request.ValidateInput("inputName", statusCode, comment);
+	if (!input)
+		return RequestResult::Error(statusCode, comment);
+
+	obs_frontend_open_source_filters(input);
+
+	return RequestResult::Success();
+}
+
+/**
+ * Opens the interact dialog of an input.
+ *
+ * @requestField inputName | String | Name of the input to open the dialog of
+ *
+ * @requestType OpenInputInteractDialog
+ * @complexity 1
+ * @rpcVersion -1
+ * @initialVersion 5.0.0
+ * @category ui
+ * @api requests
+ */
+RequestResult RequestHandler::OpenInputInteractDialog(const Request& request)
+{
+	RequestStatus::RequestStatus statusCode;
+	std::string comment;
+	OBSSourceAutoRelease input = request.ValidateInput("inputName", statusCode, comment);
+	if (!input)
+		return RequestResult::Error(statusCode, comment);
+
+	if (!(obs_source_get_output_flags(input) & OBS_SOURCE_INTERACTION))
+		return RequestResult::Error(RequestStatus::InvalidResourceState, "The specified input does not support interaction.");
+
+	obs_frontend_open_source_interaction(input);
+
+	return RequestResult::Success();
+}


### PR DESCRIPTION
### Description
Adds:
- `OpenInputPropertiesDialog`
- `OpenInputFiltersDialog`
- `OpenInputInteractDialog`

Closes #846 

### Motivation and Context
Users wanted to open the various dialogs for inputs, to use as hotkeys.

### How Has This Been Tested?
Tested OS(s): Ubuntu 20.04, ran all requests with no leaks

### Types of changes
- New request/event (non-breaking)
- Documentation change (a change to documentation pages)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
