### PR TITLE
Input audio requests and events

### DIFF
--- a/src/eventhandler/EventHandler.cpp
+++ b/src/eventhandler/EventHandler.cpp
@@ -134,6 +134,7 @@ void EventHandler::ConnectSourceSignals(obs_source_t *source) // Applies to inpu
 	signal_handler_connect(sh, "hide", HandleInputShowStateChanged, this);
 	signal_handler_connect(sh, "mute", HandleInputMuteStateChanged, this);
 	signal_handler_connect(sh, "volume", HandleInputVolumeChanged, this);
+	signal_handler_connect(sh, "audio_balance", HandleInputAudioBalanceChanged, this);
 	signal_handler_connect(sh, "audio_sync", HandleInputAudioSyncOffsetChanged, this);
 	signal_handler_connect(sh, "audio_mixers", HandleInputAudioTracksChanged, this);
 	//signal_handler_connect(sh, "audio_monitoring", HandleInputAudioMonitorTypeChanged, this);
@@ -174,6 +175,7 @@ void EventHandler::DisconnectSourceSignals(obs_source_t *source)
 	signal_handler_disconnect(sh, "hide", HandleInputShowStateChanged, this);
 	signal_handler_disconnect(sh, "mute", HandleInputMuteStateChanged, this);
 	signal_handler_disconnect(sh, "volume", HandleInputVolumeChanged, this);
+	signal_handler_disconnect(sh, "audio_balance", HandleInputAudioBalanceChanged, this);
 	signal_handler_disconnect(sh, "audio_sync", HandleInputAudioSyncOffsetChanged, this);
 	signal_handler_disconnect(sh, "audio_mixers", HandleInputAudioTracksChanged, this);
 	//signal_handler_disconnect(sh, "audio_monitoring", HandleInputAudioMonitorTypeChanged, this);

--- a/src/eventhandler/EventHandler.h
+++ b/src/eventhandler/EventHandler.h
@@ -107,6 +107,7 @@ class EventHandler
 		static void HandleInputShowStateChanged(void *param, calldata_t *data); // Direct callback
 		static void HandleInputMuteStateChanged(void *param, calldata_t *data); // Direct callback
 		static void HandleInputVolumeChanged(void *param, calldata_t *data); // Direct callback
+		static void HandleInputAudioBalanceChanged(void *param, calldata_t *data); // Direct callback
 		static void HandleInputAudioSyncOffsetChanged(void *param, calldata_t *data); // Direct callback
 		static void HandleInputAudioTracksChanged(void *param, calldata_t *data); // Direct callback
 		static void HandleInputAudioMonitorTypeChanged(void *param, calldata_t *data); // Direct callback

--- a/src/eventhandler/EventHandler_Inputs.cpp
+++ b/src/eventhandler/EventHandler_Inputs.cpp
@@ -237,6 +237,39 @@ void EventHandler::HandleInputVolumeChanged(void *param, calldata_t *data)
 }
 
 /**
+ * The audio balance value of an input has changed.
+ *
+ * @dataField inputName         | String | Name of the affected input
+ * @dataField inputAudioBalance | Number | New audio balance value of the input
+ *
+ * @eventType InputAudioBalanceChanged
+ * @eventSubscription Inputs
+ * @complexity 2
+ * @rpcVersion -1
+ * @initialVersion 5.0.0
+ * @category inputs
+ * @api events
+ */
+void EventHandler::HandleInputAudioBalanceChanged(void *param, calldata_t *data)
+{
+	auto eventHandler = reinterpret_cast<EventHandler*>(param);
+
+	obs_source_t *source = GetCalldataPointer<obs_source_t>(data, "source");
+	if (!source)
+		return;
+
+	if (obs_source_get_type(source) != OBS_SOURCE_TYPE_INPUT)
+		return;
+
+	float inputAudioBalance = (float)calldata_float(data, "balance");
+
+	json eventData;
+	eventData["inputName"] = obs_source_get_name(source);
+	eventData["inputAudioBalance"] = inputAudioBalance;
+	eventHandler->BroadcastEvent(EventSubscription::Inputs, "InputAudioBalanceChanged", eventData);
+}
+
+/**
  * The sync offset of an input has changed.
  *
  * @dataField inputName            | String | Name of the input

--- a/src/requesthandler/RequestHandler.cpp
+++ b/src/requesthandler/RequestHandler.cpp
@@ -77,6 +77,8 @@ const std::map<std::string, RequestMethodHandler> RequestHandler::_handlerMap
 	{"ToggleInputMute", &RequestHandler::ToggleInputMute},
 	{"GetInputVolume", &RequestHandler::GetInputVolume},
 	{"SetInputVolume", &RequestHandler::SetInputVolume},
+	{"GetInputAudioBalance", &RequestHandler::GetInputAudioBalance},
+	{"SetInputAudioBalance", &RequestHandler::SetInputAudioBalance},
 	{"GetInputAudioSyncOffset", &RequestHandler::GetInputAudioSyncOffset},
 	{"SetInputAudioSyncOffset", &RequestHandler::SetInputAudioSyncOffset},
 	{"GetInputAudioMonitorType", &RequestHandler::GetInputAudioMonitorType},

--- a/src/requesthandler/RequestHandler.h
+++ b/src/requesthandler/RequestHandler.h
@@ -99,6 +99,8 @@ class RequestHandler {
 		RequestResult ToggleInputMute(const Request&);
 		RequestResult GetInputVolume(const Request&);
 		RequestResult SetInputVolume(const Request&);
+		RequestResult GetInputAudioBalance(const Request&);
+		RequestResult SetInputAudioBalance(const Request&);
 		RequestResult GetInputAudioSyncOffset(const Request&);
 		RequestResult SetInputAudioSyncOffset(const Request&);
 		RequestResult GetInputAudioMonitorType(const Request&);

--- a/src/requesthandler/RequestHandler_Inputs.cpp
+++ b/src/requesthandler/RequestHandler_Inputs.cpp
@@ -489,6 +489,61 @@ RequestResult RequestHandler::SetInputVolume(const Request& request)
 }
 
 /**
+ * Gets the audio balance of an input.
+ *
+ * @requestField inputName | String | Name of the input to get the audio balance of
+ *
+ * @responseField inputAudioBalance | Number | Audio balance value from 0.0-1.0
+ *
+ * @requestType GetInputAudioBalance
+ * @complexity 2
+ * @rpcVersion -1
+ * @initialVersion 5.0.0
+ * @api requests
+ * @category inputs
+ */
+RequestResult RequestHandler::GetInputAudioBalance(const Request& request)
+{
+	RequestStatus::RequestStatus statusCode;
+	std::string comment;
+	OBSSourceAutoRelease input = request.ValidateInput("inputName", statusCode, comment);
+	if (!input)
+		return RequestResult::Error(statusCode, comment);
+
+	json responseData;
+	responseData["inputAudioBalance"] = obs_source_get_balance_value(input);
+
+	return RequestResult::Success(responseData);
+}
+
+/**
+ * Sets the audio balance of an input.
+ *
+ * @requestField inputName         | String | Name of the input to set the audio balance of
+ * @requestField inputAudioBalance | Number | New audio balance value | >= 0.0, <= 1.0
+ *
+ * @requestType SetInputAudioBalance
+ * @complexity 2
+ * @rpcVersion -1
+ * @initialVersion 5.0.0
+ * @api requests
+ * @category inputs
+ */
+RequestResult RequestHandler::SetInputAudioBalance(const Request& request)
+{
+	RequestStatus::RequestStatus statusCode;
+	std::string comment;
+	OBSSourceAutoRelease input = request.ValidateInput("inputName", statusCode, comment);
+	if (!(input && request.ValidateNumber("inputAudioBalance", statusCode, comment, 0.0, 1.0)))
+		return RequestResult::Error(statusCode, comment);
+
+	float inputAudioBalance = request.RequestData["inputAudioBalance"];
+	obs_source_set_balance_value(input, inputAudioBalance);
+
+	return RequestResult::Success();
+}
+
+/**
  * Gets the audio sync offset of an input.
  *
  * Note: The audio sync offset can be negative too!


### PR DESCRIPTION
### Description
Adds event `InputAudioBalanceChanged`

Adds requests:
- `GetInputAudioBalance`
- `SetInputAudioBalance`

Closes #858

### Motivation and Context
More features!

### How Has This Been Tested?
Tested OS(s): Ubuntu 20.04

### Types of changes
- New request/event (non-breaking)
- Documentation change (a change to documentation pages)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
