### PR TITLE
Requests: Add GetMonitorList

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # obs-websocket documentation
 
-This is the documentation for obs-websocket. Run build_docs.sh to auto generate the latest docs from the `src` directory. There are 3 components to the docs generation:
+This is the documentation for obs-websocket. Run `build_docs.sh` to auto generate the latest docs from the `src` directory. There are 3 components to the docs generation:
 - `comments/comments.js`: Generates the `work/comments.json` file from the code comments in the src directory.
 - `docs/process_comments.py`: Processes `work/comments.json` to create `generated/protocol.json`, which is a machine-readable documentation format that can be used to create obs-websocket client libraries.
 - `docs/generate_md.py`: Processes `generated/protocol.json` to create `generated/protocol.md`, which is the actual human-readable documentation.

--- a/src/requesthandler/RequestHandler.cpp
+++ b/src/requesthandler/RequestHandler.cpp
@@ -181,6 +181,7 @@ const std::unordered_map<std::string, RequestMethodHandler> RequestHandler::_han
 	{"OpenInputPropertiesDialog", &RequestHandler::OpenInputPropertiesDialog},
 	{"OpenInputFiltersDialog", &RequestHandler::OpenInputFiltersDialog},
 	{"OpenInputInteractDialog", &RequestHandler::OpenInputInteractDialog},
+	{"GetMonitorList", &RequestHandler::GetMonitorList},
 };
 
 RequestHandler::RequestHandler(SessionPtr session) :

--- a/src/requesthandler/RequestHandler.h
+++ b/src/requesthandler/RequestHandler.h
@@ -199,6 +199,7 @@ class RequestHandler {
 		RequestResult OpenInputPropertiesDialog(const Request&);
 		RequestResult OpenInputFiltersDialog(const Request&);
 		RequestResult OpenInputInteractDialog(const Request&);
+		RequestResult GetMonitorList(const Request&);
 
 		SessionPtr _session;
 		static const std::unordered_map<std::string, RequestMethodHandler> _handlerMap;


### PR DESCRIPTION
Adds a new request `GetMonitorList` that returns a json Array of
objects containing data about connected monitors. See Issue #868

### Description
Adds `GetMonitorList` endpoint as requested in #868 

### Motivation and Context
Adds the ability for clients to get monitor information. This can be useful for changing client behavior based on monitor resolution, position, presence of multiple monitors etc. 

### How Has This Been Tested?
 - tested end to end from a python script using simpleobsws (V1.3.1)
Tested OS(s): Linux, Ubuntu 21.10

### Types of changes
 - New request/event (non-breaking)
 - Documentation change (a change to documentation pages)

### Checklist:
-  [ x ] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [ x ] All commit messages are properly formatted and commits squashed where appropriate.
-  [ x ] My code is not on the `master` branch.
-  [ x ] The code has been tested.
-  [ x ] I have included updates to all appropriate documentation.
