### PR TITLE
docs: Fix wrong field name in `SceneItemLockStateChanged`

### DIFF
--- a/src/eventhandler/EventHandler_SceneItems.cpp
+++ b/src/eventhandler/EventHandler_SceneItems.cpp
@@ -158,9 +158,9 @@ void EventHandler::HandleSceneItemEnableStateChanged(void *param, calldata_t *da
 /**
  * A scene item's lock state has changed.
  *
- * @dataField sceneName        | String  | Name of the scene the item is in
- * @dataField sceneItemId      | Number  | Numeric ID of the scene item
- * @dataField sceneItemEnabled | Boolean | Whether the scene item is locked
+ * @dataField sceneName       | String  | Name of the scene the item is in
+ * @dataField sceneItemId     | Number  | Numeric ID of the scene item
+ * @dataField sceneItemLocked | Boolean | Whether the scene item is locked
  *
  * @eventType SceneItemLockStateChanged
  * @eventSubscription SceneItems


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Adjust the field name to the one that is accepted by the request.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The docs were mentioning a field that doesn't exist, probably just a copy & paste mistake.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): MacOS

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
