### PR TITLE
server: Fix int type of batch execution enum

### DIFF
--- a/src/requesthandler/types/RequestBatchExecutionType.h
+++ b/src/requesthandler/types/RequestBatchExecutionType.h
@@ -22,7 +22,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <stdint.h>
 
 namespace RequestBatchExecutionType {
-	enum RequestBatchExecutionType {
+	enum RequestBatchExecutionType: int8_t {
 		/**
 		* Not a request batch.
 		*
@@ -77,7 +77,7 @@ namespace RequestBatchExecutionType {
 		Parallel = 2,
 	};
 
-	inline bool IsValid(int executionType)
+	inline bool IsValid(int8_t executionType)
 	{
 		return executionType >= None && executionType <= Parallel;
 	}

--- a/src/websocketserver/WebSocketServer_Protocol.cpp
+++ b/src/websocketserver/WebSocketServer_Protocol.cpp
@@ -233,7 +233,7 @@ void WebSocketServer::ProcessMessage(SessionPtr session, WebSocketServer::Proces
 					return;
 				}
 
-				uint8_t requestedExecutionType = payloadData["executionType"];
+				int8_t requestedExecutionType = payloadData["executionType"];
 				if (!RequestBatchExecutionType::IsValid(requestedExecutionType) || requestedExecutionType == RequestBatchExecutionType::None) {
 					ret.closeCode = WebSocketCloseCode::InvalidDataFieldValue;
 					ret.closeReason = "Your `executionType` has an invalid value.";


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Adjusts the int type of the `RequestBatchExecutionType` enum to `int8_t` and changes the type during JSON extraction.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Clang was warning about an invalid comparison as the execution type was extract as an `uint8_t`, whereas the enum used the `int` type (default, I believe?). Changing to an `int8_t` should be more than sufficient as the enum is extremely small and it's unlikely to grow over 127 different batch execution types in the future.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): MacOS

Plugin works as expected when run. Didn't test the batch execution in particular though.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
