### PR TITLE
README: Add Godot obs-websocket-gd to library list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ It is **highly recommended** to protect obs-websocket with a password against un
 Here's a list of available language APIs for obs-websocket:
 - Python 3.7+ (Asyncio): [simpleobsws](https://github.com/IRLToolkit/simpleobsws/tree/master) by IRLToolkit
 - Rust: [obws](https://github.com/dnaka91/obws/tree/v5-api) by dnaka91
+- Godot 3.4.x: [obs-websocket-gd](https://github.com/you-win/obs-websocket-gd) by you-win
 
 The 5.x server is a typical WebSocket server running by default on port 4455 (the port number can be changed in the Settings dialog under `Tools`).
 The protocol we use is documented in [PROTOCOL.md](docs/generated/protocol.md).


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
Add the library [obs-websocket-gd](https://github.com/you-win/obs-websocket-gd) to the library list. API changes for 5.0.0 have been completed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adds obs-websocket-gd to the library list.

<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Windows 10

A small demo/test project is included in the repo which can be run against a running obs-websocket instance. The project simply echos the response from obs-websocket.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on the `master` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
