### PR TITLE
Server: Add --websocket_ipv4_only switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Binaries for Windows, MacOS, and Linux are available in the [Releases](https://g
 
 It is **highly recommended** to protect obs-websocket with a password against unauthorized control. To do this, open the "Websocket server settings" dialog under OBS' "Tools" menu. In the settings dialogs, you can enable or disable authentication and set a password for it.
 
-(Psst. You can use `--websocket_port`(value), `--websocket_password`(value), and `--websocket_debug`(flag) on the command line to override the configured values.)
+(Psst. You can use `--websocket_port`(value), `--websocket_password`(value), `--websocket_debug`(flag) and `--websocket_ipv4_only`(flag) on the command line to override the configured values.)
 
 ### Possible use cases
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -33,6 +33,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #define PARAM_PASSWORD "ServerPassword"
 
 #define CMDLINE_WEBSOCKET_PORT "websocket_port"
+#define CMDLINE_WEBSOCKET_IPV4_ONLY "websocket_ipv4_only"
 #define CMDLINE_WEBSOCKET_PASSWORD "websocket_password"
 #define CMDLINE_WEBSOCKET_DEBUG "websocket_debug"
 
@@ -42,6 +43,7 @@ Config::Config() :
 	FirstLoad(true),
 	ServerEnabled(true),
 	ServerPort(4455),
+	Ipv4Only(false),
 	DebugEnabled(false),
 	AlertsEnabled(false),
 	AuthRequired(true),
@@ -91,6 +93,12 @@ void Config::Load()
 		} else {
 			blog(LOG_WARNING, "[Config::Load] Not overriding WebSocket port since integer conversion failed.");
 		}
+	}
+
+	// Process `--websocket_ipv4_only` override
+	if (Utils::Platform::GetCommandLineFlagSet(CMDLINE_WEBSOCKET_IPV4_ONLY)) {
+		blog(LOG_INFO, "[Config::Load] --websocket_ipv4_only passed. Binding only to IPv4 interfaces.");
+		Ipv4Only = true;
 	}
 
 	// Process `--websocket_password` override

--- a/src/Config.h
+++ b/src/Config.h
@@ -38,6 +38,7 @@ struct Config {
 	std::atomic<bool> FirstLoad;
 	std::atomic<bool> ServerEnabled;
 	std::atomic<uint16_t> ServerPort;
+	std::atomic<bool> Ipv4Only;
 	std::atomic<bool> DebugEnabled;
 	std::atomic<bool> AlertsEnabled;
 	std::atomic<bool> AuthRequired;

--- a/src/websocketserver/WebSocketServer.cpp
+++ b/src/websocketserver/WebSocketServer.cpp
@@ -129,7 +129,13 @@ void WebSocketServer::Start()
 	_server.reset();
 
 	websocketpp::lib::error_code errorCode;
-	_server.listen(websocketpp::lib::asio::ip::tcp::v4(), conf->ServerPort, errorCode);
+	if (conf->Ipv4Only) {
+		blog(LOG_INFO, "[WebSocketServer::Start] Locked to IPv4 bindings");
+		_server.listen(websocketpp::lib::asio::ip::tcp::v4(), conf->ServerPort, errorCode);
+	} else {
+		blog(LOG_INFO, "[WebSocketServer::Start] Not locked to IPv4 bindings");
+		_server.listen(conf->ServerPort, errorCode);
+	}
 
 	if (errorCode) {
 		std::string errorCodeMessage = errorCode.message();


### PR DESCRIPTION
Socket listening default changed to IPv4 and IPv6,
overridable to IPv4 only by using the command line switch.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->

Switch websocketpp binding to both IPv4 & IPv6 by default. Add command line switch to force IPv4 only.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

To enable IPv6.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 

Kubuntu 21.10.
OBS Studio: 27.2.2-0obsproject1~impish

Using "ss -plunt" example output, with command line switch to limit to IPv4:

tcp LISTEN 0 4096 0.0.0.0:4455 0.0.0.0:* users:(("obs",pid=6059,fd=14))

And without:

tcp LISTEN 0 4096 *:4455 : users:(("obs",pid=6059,fd=14))

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
- Other Enhancement (anything not applicable to what is listed)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x ] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x ] All commit messages are properly formatted and commits squashed where appropriate.
-  [x ] My code is not on the `master` branch.
-  [x ] The code has been tested.
-  [x ] I have included updates to all appropriate documentation.
