### PR TITLE
Events: Fix memory leak

### DIFF
--- a/src/WSEvents.cpp
+++ b/src/WSEvents.cpp
@@ -610,8 +610,10 @@ void WSEvents::OnTransitionListChange() {
  */
 void WSEvents::OnProfileChange() {
 	OBSDataAutoRelease fields = obs_data_create();
-	obs_data_set_string(fields, "profile", obs_frontend_get_current_profile());
+	char *profile = obs_frontend_get_current_profile();
+	obs_data_set_string(fields, "profile", profile);
 	broadcastUpdate("ProfileChanged", fields);
+	bfree(profile);
 }
 
 /**


### PR DESCRIPTION
`bfree` was missing after calling `obs_frontend_get_current_profile()`.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Free the returned pointer from `obs_frontend_get_current_profile()`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

There was a memory leak after changing profile of OBS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Fedora 34.

Steps:
1. Start OBS
2. Change the current profile
3. Exit OBS
4. Check memory leaks

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
