### PR TITLE
Config: Change section name

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -26,7 +26,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <QtWidgets/QInputDialog>
 #include <QtWidgets/QMessageBox>
 
-#define SECTION_NAME "WebsocketAPI"
+#define SECTION_NAME "WebsocketAPICompat"
 #define PARAM_ENABLE "ServerEnabled"
 #define PARAM_PORT "ServerPort"
 #define PARAM_LOCKTOIPV4 "LockToIPv4"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->

This commit changes the section name for obs-websocket-compat.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The plugin `obs-websocket-compat` is expected to run with `obs-websocket` at the same time. When having two websocket plugins, both read the same port number and tried to listen the same port, which causes error.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Fedora 34.

At the boot time of OBS, it showed an error message that the address is in use.
After this change, I confirmed there is no such error message after setting different port numbers to both plugins.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
