### PR TITLE
README: Add a Go client library to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Here's a list of available language APIs for obs-websocket:
 - Godot 3.4.x: [obs-websocket-gd](https://github.com/you-win/obs-websocket-gd) by you-win
 - Javascript (Node and web): [obs-websocket-js](https://github.com/obs-websocket-community-projects/obs-websocket-js) by OBS Websocket Community
   - C (uses obs-websocket-js): [v8-libwebsocket-obs-websocket](https://github.com/dgatwood/v8-libwebsocket-obs-websocket)
+- Go: [goobs](https://github.com/andreykaipov/goobs) by andreykaipov
 
 The 5.x server is a typical WebSocket server running by default on port 4455 (the port number can be changed in the Settings dialog under `Tools`).
 The protocol we use is documented in [PROTOCOL.md](docs/generated/protocol.md).


### PR DESCRIPTION
### Description
I finally had the opportunity migrate the Go library to the v5 protocol, and would like to add it back to the list!

### Motivation and Context
To spread the love!

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Windows, Ubuntu via WSL, Alpine via Docker

Most of the code is generated from the `protocol.json`, and so are the functional tests!

### Types of changes
- Documentation change (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
