### PR TITLE
Update non-MSVC compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,15 +155,18 @@ endif()
 # Random other things
 if(WIN32)
   add_definitions(-D_WEBSOCKETPP_CPP11_STL_)
+endif()
+
+if(MSVC)
   target_compile_options(obs-websocket PRIVATE /wd4267 /wd4996)
-elseif(UNIX AND NOT APPLE)
+else()
   target_compile_options(
-    obs-websocket PRIVATE -Wall -Wextra -Wno-missing-field-initializers
-                          -Wno-variadic-macros -Wno-error=format-overflow)
-elseif(APPLE)
-  target_compile_options(
-    obs-websocket PRIVATE -Wno-error=null-pointer-subtraction
-                          -Wno-error=deprecated-declarations)
+    obs-websocket
+    PRIVATE
+      -Wall
+      "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-error=format-overflow>"
+      "$<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-error=null-pointer-subtraction;-Wno-error=deprecated-declarations>"
+  )
 endif()
 
 # Final CMake helpers


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description

- Update compile options to allow the usage of Clang under Linux (and maybe even Windows).
- Remove some `-Wno-*` options that does not seem to be required anymore.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

Cleanup and allow building with Clang on Linux.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 
- ArchLinux with Clang 14 and GCC 12
- https://github.com/obsproject/obs-studio/pull/6759 CI

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
