### PR TITLE
RequestHandler: fix typo documentation

### DIFF
--- a/src/requesthandler/RequestHandler_Record.cpp
+++ b/src/requesthandler/RequestHandler_Record.cpp
@@ -23,7 +23,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
  * Gets the status of the record output.
  *
  * @responseField outputActive        | Boolean | Whether the output is active
- * @responseField ouputPaused         | Boolean | Whether the output is paused
+ * @responseField outputPaused        | Boolean | Whether the output is paused
  * @responseField outputTimecode      | String  | Current formatted timecode string for the output
  * @responseField outputDuration      | Number  | Current duration in milliseconds for the output
  * @responseField outputBytes         | Number  | Number of bytes sent by the output


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Because the documentation is generated based on the comments, i spotted a typo that may lead to confusion. I just corrected the typo.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I had an issue with a client library ([obs_websocket](https://github.com/faithoflifedev/obs_websocket) by faithoflifedev) that used the documentation to create his models, but because of the typo in the official documentation the client library model is wrong and non-functional, then I think it is important to provide a 100% accurate documentation.
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): /

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
 - Documentation change (a change to documentation pages) 
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
