### PR TITLE
Requests: Add Missing Response Fields to Documentation

### DIFF
--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -4525,6 +4525,12 @@ Gets the list of available outputs.
 - Latest Supported RPC Version: `1`
 - Added in v5.0.0
 
+**Response Fields:**
+
+| Name | Type  | Description |
+| ---- | :---: | ----------- |
+| outputs | Array&lt;Object&gt; | Array of outputs |
+
 ---
 
 ### GetOutputStatus
@@ -4751,6 +4757,12 @@ Toggles the status of the record output.
 - Complexity Rating: `1/5`
 - Latest Supported RPC Version: `1`
 - Added in v5.0.0
+
+**Response Fields:**
+
+| Name | Type  | Description |
+| ---- | :---: | ----------- |
+| outputActive | Boolean | Whether the output is active |
 
 ---
 


### PR DESCRIPTION
### Description
Adds missing **Response fields** sections to documentation

### Motivation and Context
There was missing context on responses received when actions called.

### How Has This Been Tested?
Tested OS(s): Windows 11
Using a custom C# WebSocket Client API, called both functions and updated
documentation with perceived results.

### Types of changes
- Documentation change (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
