### PR TITLE
Fix description of "mul" volume notation

### DIFF
--- a/src/eventhandler/EventHandler_Inputs.cpp
+++ b/src/eventhandler/EventHandler_Inputs.cpp
@@ -200,7 +200,7 @@ void EventHandler::HandleInputMuteStateChanged(void *param, calldata_t *data)
  * An input's volume level has changed.
  *
  * @dataField inputName      | String | Name of the input
- * @dataField inputVolumeMul | Number | New volume level in multimap
+ * @dataField inputVolumeMul | Number | New volume level multiplier
  * @dataField inputVolumeDb  | Number | New volume level in dB
  *
  * @eventType InputVolumeChanged


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
Small docs fix - this is not a multimap, it's a simple linear multiplier (the square root of the quadratic scale that would be shown to a user).

### Motivation and Context
Clarify documentation

### How Has This Been Tested?
Looks fine visually. Docs-only change.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
