### PR TITLE
Requests: Add `inputActive` field to `GetInputList` response

### DIFF
--- a/src/utils/Obs_ArrayHelper.cpp
+++ b/src/utils/Obs_ArrayHelper.cpp
@@ -196,6 +196,7 @@ std::vector<json> Utils::Obs::ArrayHelper::GetInputList(std::string inputKind)
 		json inputJson;
 		inputJson["inputName"] = obs_source_get_name(input);
 		inputJson["inputKind"] = inputKind;
+		inputJson["inputActive"] = obs_source_active(input);
 		inputJson["unversionedInputKind"] = obs_source_get_unversioned_id(input);
 
 		inputInfo->inputs.push_back(inputJson);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
Adds `inputActive` bool to objects in the `GetInputList` response

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
There isn't currently a way to determine which inputs are active, without hacks(*)

This field makes loading the state much easier. So we can show only active inputs in an audio mixer, like the OBS frontend does.

(* Only active inputs are sent in the high frequency InputVolumeMeters event, so you filter based on an input's presence in that)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): compiles in a Linux container ☑️ 

Can't easily test further atm.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [-] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
