### PR TITLE
Add CustomEvent docs entry

### DIFF
--- a/docs/generated/protocol.json
+++ b/docs/generated/protocol.json
@@ -5664,6 +5664,23 @@
           "valueDescription": "Vendor-provided event data. {} if event does not provide any data"
         }
       ]
+    },
+    {
+      "description": "Custom event emitted by `BroadcastCustomEvent`.",
+      "eventType": "CustomEvent",
+      "eventSubscription": "General",
+      "complexity": 1,
+      "rpcVersion": "1",
+      "deprecated": false,
+      "initialVersion": "5.0.0",
+      "category": "general",
+      "dataFields": [
+        {
+          "valueName": "eventData",
+          "valueType": "Object",
+          "valueDescription": "Custom event data"
+        }
+      ]
     }
   ]
 }

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -1304,6 +1304,7 @@ Subscription value to receive the `SceneItemTransformChanged` high-volume event.
 - [General Events](#general-events)
   - [ExitStarted](#exitstarted)
   - [VendorEvent](#vendorevent)
+  - [CustomEvent](#customevent)
 - [Config Events](#config-events)
   - [CurrentSceneCollectionChanging](#currentscenecollectionchanging)
   - [CurrentSceneCollectionChanged](#currentscenecollectionchanged)
@@ -1394,6 +1395,22 @@ If a plugin or script implements vendor requests or events, documentation is exp
 | vendorName | String | Name of the vendor emitting the event |
 | eventType | String | Vendor-provided event typedef |
 | eventData | Object | Vendor-provided event data. {} if event does not provide any data |
+
+---
+
+### CustomEvent
+
+Custom event emitted by `BroadcastCustomEvent`.
+
+- Complexity Rating: `1/5`
+- Latest Supported RPC Version: `1`
+- Added in v5.0.0
+
+**Data Fields:**
+
+| Name | Type  | Description |
+| ---- | :---: | ----------- |
+| eventData | Object | Custom event data |
 
 ## Config Events
 

--- a/src/requesthandler/RequestHandler_General.cpp
+++ b/src/requesthandler/RequestHandler_General.cpp
@@ -103,6 +103,20 @@ RequestResult RequestHandler::GetStats(const Request &)
 }
 
 /**
+ * Custom event emitted by `BroadcastCustomEvent`.
+ * 
+ * @dataField eventData | Object | Custom event data
+ *
+ * @eventType CustomEvent
+ * @eventSubscription General
+ * @complexity 1
+ * @rpcVersion -1
+ * @initialVersion 5.0.0
+ * @category general
+ * @api events
+ */
+
+/**
  * Broadcasts a `CustomEvent` to all WebSocket clients. Receivers are clients which are identified and subscribed.
  *
  * @requestField eventData | Object | Data payload to emit to all receivers


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->

Adds docstring for `CustomEvent`.

I wasn't sure where to add this (I'm new to the codebase and not fluent in C++). It looks like all other doc entries correspond 1:1 with a method, however I couldn't find any method that uses `CustomEvent` except for `RequestHandler::BroadcastCustomEvent` which already has a docstring.

So, I just put another docstring above that and it seems to generate the docs correctly.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->


Resolves #1031


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s):  MacOS 12.6

I ran `build_docs.sh` to visually test the changed docs

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
- Documentation change (a change to documentation pages)
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
