### PR TITLE
docs: Fix ouputPaused typo

### DIFF
--- a/src/requesthandler/RequestHandler_Record.cpp
+++ b/src/requesthandler/RequestHandler_Record.cpp
@@ -23,7 +23,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
  * Gets the status of the record output.
  *
  * @responseField outputActive        | Boolean | Whether the output is active
- * @responseField ouputPaused         | Boolean | Whether the output is paused
+ * @responseField outputPaused        | Boolean | Whether the output is paused
  * @responseField outputTimecode      | String  | Current formatted timecode string for the output
  * @responseField outputDuration      | Number  | Current duration in milliseconds for the output
  * @responseField outputBytes         | Number  | Number of bytes sent by the output


### PR DESCRIPTION
### Description
I fixed this typo in ouputPaused, in the record status event.

### Motivation and Context
This PR fixes the generated Doc and official client libs like obs-websocket-js.

### How Has This Been Tested?
Tested OS(s): Windows 11

### Types of changes
- Documentation change (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
