### PR TITLE
Note failure state & response of `SendStreamCaption`

### DIFF
--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -4724,6 +4724,7 @@ Sends CEA-608 caption text over the stream output.
 - Complexity Rating: `2/5`
 - Latest Supported RPC Version: `1`
 - Added in v5.0.0
+- Returns a `501` error code if stream is not active.
 
 **Request Fields:**
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Add a line to protocol.md under SendStreamCaption to note that it will error with no message and a 501 error code if the request is sent when the stream is not active.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Incomplete documentation.
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
#1048 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): macOS 12.6, Windows 10, Windows 11

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
Documentation change (a change to documentation pages)
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
