### PR TITLE
base: Disable Qt RCC timestamps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ set_target_properties(
   PROPERTIES AUTOMOC ON
              AUTOUIC ON
              AUTORCC ON)
+set_property(
+    TARGET obs-websocket
+    APPEND
+    PROPERTY AUTORCC_OPTIONS --format-version 1)
 
 target_sources(
   obs-websocket


### PR DESCRIPTION
### Description

Disables timestamps in Qt resources to make builds reproducible.

### Motivation and Context

Complete https://github.com/obsproject/obs-studio/pull/8220 (obs-websocket is the only component not reproducible right now)

### How Has This Been Tested?

Has not been tested directly yet, but the same change in OBS itself worked.

### Types of changes

- Other Enhancement (anything not applicable to what is listed)

### Checklist:

-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [ ] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
