### PR TITLE
requesthandler: Fix existing input/scene detection in create

### DIFF
--- a/src/requesthandler/RequestHandler_Inputs.cpp
+++ b/src/requesthandler/RequestHandler_Inputs.cpp
@@ -149,7 +149,7 @@ RequestResult RequestHandler::CreateInput(const Request &request)
 
 	std::string inputName = request.RequestData["inputName"];
 	OBSSourceAutoRelease existingInput = obs_get_source_by_name(inputName.c_str());
-	if (existingInput)
+	if (existingInput && !obs_source_removed(existingInput))
 		return RequestResult::Error(RequestStatus::ResourceAlreadyExists, "A source already exists by that input name.");
 
 	std::string inputKind = request.RequestData["inputKind"];

--- a/src/requesthandler/RequestHandler_Scenes.cpp
+++ b/src/requesthandler/RequestHandler_Scenes.cpp
@@ -202,7 +202,7 @@ RequestResult RequestHandler::CreateScene(const Request &request)
 	std::string sceneName = request.RequestData["sceneName"];
 
 	OBSSourceAutoRelease scene = obs_get_source_by_name(sceneName.c_str());
-	if (scene)
+	if (scene && !obs_source_removed(scene))
 		return RequestResult::Error(RequestStatus::ResourceAlreadyExists, "A source already exists by that scene name.");
 
 	obs_scene_t *createdScene = obs_scene_create(sceneName.c_str());


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Allow re-creating an input/scene with the same name in case the previous instance has already been marked for deletion.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Deleting and re-creating an input or scene by using the same name, in consecutive requests, currently throws an "already exists", despite those items already being marked for deletion in OBS.

Here's the code snippet, using OBS Websocket's javascript bindings, for triggering the error:
```
import OBSWebSocket from 'obs-websocket-js';

const obs = new OBSWebSocket();
const sceneName = 'Scene';

await obs.call('RemoveScene', { sceneName });
await obs.call('CreateScene', { sceneName }); // Will throw "A source already exists by that scene name."
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Debian 11

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
