### PR TITLE
requesthandler: Deprecate SetStreamServiceSettings

### DIFF
--- a/src/requesthandler/RequestHandler_Config.cpp
+++ b/src/requesthandler/RequestHandler_Config.cpp
@@ -564,7 +564,7 @@ RequestResult RequestHandler::GetStreamServiceSettings(const Request &)
  *
  * @requestType SetStreamServiceSettings
  * @complexity 4
- * @rpcVersion -1
+ * @rpcVersion 1
  * @initialVersion 5.0.0
  * @category config
  * @api requests
@@ -607,11 +607,13 @@ RequestResult RequestHandler::SetStreamServiceSettings(const Request &request)
 			return RequestResult::Error(
 				RequestStatus::ResourceCreationFailed,
 				"Failed to create the stream service with the requested streamServiceType. It may be an invalid type.");
-
+		PRAGMA_WARN_PUSH
+		PRAGMA_WARN_DEPRECATION
 		obs_frontend_set_streaming_service(newStreamService);
 	}
 
 	obs_frontend_save_streaming_service();
+	PRAGMA_WARN_POP
 
 	return RequestResult::Success();
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->

RFC 39 plan to overhaul services in OBS Studio, unfortunately `SetStreamServiceSettings` use two functions that needs to be deprecated and then dropped while landing RFC 39 to avoid issues. So `SetStreamServiceSettings` also must be deprecated.

`obs_frontend_save_streaming_service`, plugin should not be able to override what is saved by the settings window.

Since output selection is planned to be moved in settings, `SetStreamServiceSettings` allows to set a service that might mismatch the used output (and even encoders depending on the protocol and services).

At the present time, I can't promise replacement for those functions in RFC 39.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

Make a clean deprecation plan for those functions.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->
- Deprecation

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [ ] The code has been tested.
-  [ ] I have included updates to all appropriate documentation.
   - Should I run `./build_docs.sh` and include the changes ?
