### PR TITLE
base: Fix generated header inclusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,8 +127,8 @@ target_sources(
 
 target_sources(obs-websocket PRIVATE deps/qr/cpp/QrCode.cpp deps/qr/cpp/QrCode.hpp)
 
-configure_file(src/plugin-macros.h.in src/plugin-macros.generated.h)
-target_sources(obs-websocket PRIVATE src/plugin-macros.generated.h)
+configure_file(src/plugin-macros.h.in plugin-macros.generated.h)
+target_sources(obs-websocket PRIVATE plugin-macros.generated.h)
 
 target_compile_definitions(
   obs-websocket PRIVATE ASIO_STANDALONE $<$<BOOL:PLUGIN_TESTS>:PLUGIN_TESTS>

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -32,8 +32,7 @@ find_package(Asio 1.12.1 REQUIRED)
 add_definitions(-DASIO_STANDALONE)
 
 # Configure files
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/plugin-macros.h.in
-               ${CMAKE_CURRENT_SOURCE_DIR}/src/plugin-macros.generated.h)
+configure_file(src/plugin-macros.h.in plugin-macros.generated.h)
 
 # Setup target
 add_library(obs-websocket MODULE)
@@ -48,6 +47,8 @@ set_target_properties(
 if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
   set_target_properties(obs-websocket PROPERTIES AUTORCC_OPTIONS "--format-version;1")
 endif()
+
+target_include_directories(obs-websocket PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 target_sources(
   obs-websocket

--- a/src/eventhandler/EventHandler.h
+++ b/src/eventhandler/EventHandler.h
@@ -27,7 +27,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include "../obs-websocket.h"
 #include "../utils/Obs.h"
 #include "../utils/Obs_VolumeMeter.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 class EventHandler {
 public:

--- a/src/forms/ConnectInfo.h
+++ b/src/forms/ConnectInfo.h
@@ -21,7 +21,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <QtWidgets/QDialog>
 
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 #include "ui_ConnectInfo.h"
 

--- a/src/forms/SettingsDialog.h
+++ b/src/forms/SettingsDialog.h
@@ -23,7 +23,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <QTimer>
 
 #include "ConnectInfo.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 #include "ui_SettingsDialog.h"
 

--- a/src/requesthandler/RequestHandler.h
+++ b/src/requesthandler/RequestHandler.h
@@ -30,7 +30,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include "../websocketserver/rpc/WebSocketSession.h"
 #include "../obs-websocket.h"
 #include "../utils/Obs.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 class RequestHandler;
 typedef RequestResult (RequestHandler::*RequestMethodHandler)(const Request &);

--- a/src/utils/Crypto.cpp
+++ b/src/utils/Crypto.cpp
@@ -22,7 +22,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <QRandomGenerator>
 
 #include "Crypto.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 static const char allowedChars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 static const int allowedCharsCount = static_cast<int>(sizeof(allowedChars) - 1);

--- a/src/utils/Json.cpp
+++ b/src/utils/Json.cpp
@@ -19,7 +19,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include "Json.h"
 #include "Platform.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 bool Utils::Json::JsonArrayIsValidObsArray(const json &j)
 {

--- a/src/utils/Obs.cpp
+++ b/src/utils/Obs.cpp
@@ -18,4 +18,4 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
 #include "Obs.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"

--- a/src/utils/Obs_ActionHelper.cpp
+++ b/src/utils/Obs_ActionHelper.cpp
@@ -17,7 +17,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
 #include "Obs.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 struct CreateSceneItemData {
 	obs_source_t *source;                             // In

--- a/src/utils/Obs_ArrayHelper.cpp
+++ b/src/utils/Obs_ArrayHelper.cpp
@@ -20,7 +20,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <algorithm>
 
 #include "Obs.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 static std::vector<std::string> ConvertStringArray(char **array)
 {

--- a/src/utils/Obs_NumberHelper.cpp
+++ b/src/utils/Obs_NumberHelper.cpp
@@ -21,7 +21,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <util/util_uint64.h>
 
 #include "Obs.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 uint64_t Utils::Obs::NumberHelper::GetOutputDuration(obs_output_t *output)
 {

--- a/src/utils/Obs_ObjectHelper.cpp
+++ b/src/utils/Obs_ObjectHelper.cpp
@@ -21,7 +21,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include "Obs.h"
 #include "../obs-websocket.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 json Utils::Obs::ObjectHelper::GetStats()
 {

--- a/src/utils/Obs_SearchHelper.cpp
+++ b/src/utils/Obs_SearchHelper.cpp
@@ -17,7 +17,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
 #include "Obs.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 obs_hotkey_t *Utils::Obs::SearchHelper::GetHotkeyByName(std::string name)
 {

--- a/src/utils/Obs_StringHelper.cpp
+++ b/src/utils/Obs_StringHelper.cpp
@@ -21,7 +21,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <QString>
 
 #include "Obs.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 #define CASE(x) \
 	case x: \

--- a/src/utils/Platform.cpp
+++ b/src/utils/Platform.cpp
@@ -25,7 +25,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <obs-frontend-api.h>
 
 #include "Platform.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 std::string Utils::Platform::GetLocalAddress()
 {

--- a/src/websocketserver/WebSocketServer.h
+++ b/src/websocketserver/WebSocketServer.h
@@ -32,7 +32,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include "types/WebSocketOpCode.h"
 #include "../utils/Json.h"
 #include "../requesthandler/rpc/Request.h"
-#include "../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 class WebSocketServer : QObject {
 	Q_OBJECT

--- a/src/websocketserver/rpc/WebSocketSession.h
+++ b/src/websocketserver/rpc/WebSocketSession.h
@@ -24,7 +24,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <atomic>
 #include <memory>
 
-#include "../../plugin-macros.generated.h"
+#include "plugin-macros.generated.h"
 
 class WebSocketSession;
 typedef std::shared_ptr<WebSocketSession> SessionPtr;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->

Fix generated header inclusion that is actually broken on CMake 3.0 which break macOS build.

To fix it the right way, changes to CMake 2.0 and `#include`s should be done.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

Fix macOS CIs

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): ArchLinux (CMake 2.0)

macOS CIs does build on my OBS Studio fork.
Run: https://github.com/tytan652/obs-studio/actions/runs/4531877056

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
