### PR TITLE
cmake: Silences Qt warnings emitted by clang with default Xcode settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ target_compile_options(
     $<$<PLATFORM_ID:Darwin,Linux,FreeBSD>:-Wall>
     $<$<COMPILE_LANG_AND_ID:CXX,GNU,AppleClang,Clang>:-Wno-error=float-conversion;-Wno-error=shadow>
     $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-error=format-overflow;-Wno-error=int-conversion;-Wno-error=comment>
-    $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-error=null-pointer-subtraction;-Wno-error=deprecated-declarations;-Wno-error=implicit-int-conversion;-Wno-error=shorten-64-to-32>
+    $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-error=null-pointer-subtraction;-Wno-error=deprecated-declarations;-Wno-error=implicit-int-conversion;-Wno-error=shorten-64-to-32;-Wno-comma;-Wno-quoted-include-in-framework-header>
 )
 
 target_link_libraries(


### PR DESCRIPTION
### Description
Silences warnings triggered by Qt code design (relying on questionable comma usage and using quoted header imports in their Frameworks).

### Motivation and Context
Required for https://github.com/obsproject/obs-studio/pull/8678

### How Has This Been Tested?
Tested on macOS 13 with Xcode default compiler settings.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
