### PR TITLE
RequestHandler: Fix memory leak when setting streaming service

### DIFF
--- a/src/requesthandler/RequestHandler_Config.cpp
+++ b/src/requesthandler/RequestHandler_Config.cpp
@@ -599,9 +599,9 @@ RequestResult RequestHandler::SetStreamServiceSettings(const Request &request)
 
 		obs_service_update(currentStreamService, newStreamServiceSettings);
 	} else {
-		// TODO: This leaks memory. I have no idea why.
-		OBSService newStreamService = obs_service_create(requestedStreamServiceType.c_str(), "obs_websocket_custom_service",
-								 requestedStreamServiceSettings, nullptr);
+		OBSServiceAutoRelease newStreamService = obs_service_create(requestedStreamServiceType.c_str(),
+									    "obs_websocket_custom_service",
+									    requestedStreamServiceSettings, nullptr);
 		// TODO: Check service type here, instead of relying on service creation to fail.
 		if (!newStreamService)
 			return RequestResult::Error(


### PR DESCRIPTION
### Description
<!--- Describe your changes. -->

Replaced `OBSService` type with `OBSServiceAutoRelease` in `RequestHandler::SetStreamServiceSettings`.



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Memory leaks when setting streaming service using obs-websocket.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Ubuntu 22.04

Steps to test the memory-leak is as below.

1. Start obs with clean configuration
   ```
   export XDG_CONFIG_HOME=$(mktemp -d /dev/shm/obs-XXXXXX)
   obs &
   ```
   1. In the wizard, configure `Optimize just for recording, I will not be streaming`.
2. Enable WebSocket server
   1. also disable password for simple testing.
4. Run these lines in python3
   ```
   import obsws_python
   cl = obsws_python.ReqClient(host='localhost', port=4455)
   cl.send('SetStreamServiceSettings', {
       'streamServiceType': 'rtmp_custom',
       'streamServiceSettings': {
           'server': 'rtmp://localhost/live',
           'key': 'secret',
           }})
   ```
5. Exit obs


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
