### PR TITLE
base,deps,src: Replace qr submodule by prefix/system install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/qr"]
-	path = deps/qr
-	url = https://github.com/nayuki/QR-Code-generator.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,16 +11,14 @@ if(NOT ENABLE_WEBSOCKET)
   return()
 endif()
 
-# Submodule deps check
-if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/deps/qr/cpp/QrCode.hpp")
-  message(FATAL_ERROR "obs-websocket submodule deps not available.")
-endif()
-
 # Find Qt
 find_qt(COMPONENTS Core Widgets Svg Network)
 
 # Find nlohmann JSON
 find_package(nlohmann_json 3 REQUIRED)
+
+# Find qrcodegencpp
+find_package(Libqrcodegencpp REQUIRED)
 
 # Find WebSocket++
 find_package(Websocketpp 0.8 REQUIRED)
@@ -124,8 +122,6 @@ target_sources(
           src/utils/Platform.h
           src/utils/Utils.h)
 
-target_sources(obs-websocket PRIVATE deps/qr/cpp/QrCode.cpp deps/qr/cpp/QrCode.hpp)
-
 configure_file(src/plugin-macros.h.in plugin-macros.generated.h)
 target_sources(obs-websocket PRIVATE plugin-macros.generated.h)
 
@@ -154,7 +150,8 @@ target_link_libraries(
           Qt::Network
           nlohmann_json::nlohmann_json
           Websocketpp::Websocketpp
-          Asio::Asio)
+          Asio::Asio
+          Libqrcodegencpp::Libqrcodegencpp)
 
 set_target_properties_obs(
   obs-websocket

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -8,11 +8,6 @@ if(NOT ENABLE_WEBSOCKET OR NOT ENABLE_UI)
   return()
 endif()
 
-# Submodule deps check
-if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/deps/qr/cpp/QrCode.hpp)
-  obs_status(FATAL_ERROR "obs-websocket submodule deps not available.")
-endif()
-
 # Plugin tests flag
 option(PLUGIN_TESTS "Enable plugin runtime tests" OFF)
 
@@ -21,6 +16,9 @@ find_qt(COMPONENTS Core Widgets Svg Network)
 
 # Find nlohmann JSON
 find_package(nlohmann_json 3 REQUIRED)
+
+# Find qrcodegencpp
+find_package(Libqrcodegencpp REQUIRED)
 
 # Find WebSocket++
 find_package(Websocketpp 0.8 REQUIRED)
@@ -127,9 +125,7 @@ target_sources(
           src/utils/Platform.h
           src/utils/Compat.cpp
           src/utils/Compat.h
-          src/utils/Utils.h
-          deps/qr/cpp/QrCode.cpp
-          deps/qr/cpp/QrCode.hpp)
+          src/utils/Utils.h)
 
 target_link_libraries(
   obs-websocket
@@ -141,7 +137,8 @@ target_link_libraries(
           Qt::Network
           nlohmann_json::nlohmann_json
           Websocketpp::Websocketpp
-          Asio::Asio)
+          Asio::Asio
+          Libqrcodegencpp::Libqrcodegencpp)
 
 target_compile_features(obs-websocket PRIVATE cxx_std_17)
 

--- a/src/forms/ConnectInfo.cpp
+++ b/src/forms/ConnectInfo.cpp
@@ -21,9 +21,9 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <QPainter>
 #include <QUrl>
 #include <obs-module.h>
+#include <qrcodegen.hpp>
 
 #include "ConnectInfo.h"
-#include "../../deps/qr/cpp/QrCode.hpp"
 #include "../obs-websocket.h"
 #include "../Config.h"
 #include "../utils/Platform.h"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->

Requires to work on obs-studio repo:
 - https://github.com/obsproject/obs-deps/pull/182
 - https://github.com/obsproject/obs-studio/pull/8943
 - **Drop Ubuntu 20.04**, related CI will failed because of an API break from Libqrcodegen between 1.5.0 (20.04) and 1.7.0 (22.04) (header file name change) with obs-websocket PRs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

Reduce to zero the number of submodule in obs-websocket repo.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Arch Linux

Test binaries available on a PR on my obs-studio fork: https://github.com/tytan652/obs-studio/pull/13

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
- Other Enhancement (anything not applicable to what is listed)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
