### PR TITLE
locale: Remove obsolete translations

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -45,6 +45,3 @@ OBSWebSocket.TrayNotification.AuthenticationFailed.Title="WebSocket Authenticati
 OBSWebSocket.TrayNotification.AuthenticationFailed.Body="Client %1 failed to authenticate."
 OBSWebSocket.TrayNotification.Disconnected.Title="WebSocket Client Disconnected"
 OBSWebSocket.TrayNotification.Disconnected.Body="Client %1 disconnected."
-
-OBSWebSocket.Server.StartFailed.Title="WebSocket Server Failure"
-OBSWebSocket.Server.StartFailed.Message="The WebSocket server failed to start. TCP port %1 may already be in use elsewhere on this system by another application. Try setting a different TCP port in the WebSocket server settings, or stop any application that could be using this port.\n Error message: %2"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Remove two obsolete translations `OBSWebSocket.Server.StartFailed.Title` and `OBSWebSocket.Server.StartFailed.Message`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

The text was originally introduced at the commit d76ff16162bcbbc07c9c2538624e515070c916f9.
The source code using the text was later removed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Linux

Checked that a command below shows nothing.
```
git grep StartFailed ':(exclude)*.ini'
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
