### PR TITLE
Requests: Add ToggleSceneItemEnabled

### DIFF
--- a/src/requesthandler/RequestHandler.cpp
+++ b/src/requesthandler/RequestHandler.cpp
@@ -132,6 +132,7 @@ const std::unordered_map<std::string, RequestMethodHandler> RequestHandler::_han
 	{"SetSceneItemTransform", &RequestHandler::SetSceneItemTransform},
 	{"GetSceneItemEnabled", &RequestHandler::GetSceneItemEnabled},
 	{"SetSceneItemEnabled", &RequestHandler::SetSceneItemEnabled},
+	{"ToggleSceneItemEnabled", &RequestHandler::ToggleSceneItemEnabled},
 	{"GetSceneItemLocked", &RequestHandler::GetSceneItemLocked},
 	{"SetSceneItemLocked", &RequestHandler::SetSceneItemLocked},
 	{"GetSceneItemIndex", &RequestHandler::GetSceneItemIndex},

--- a/src/requesthandler/RequestHandler.h
+++ b/src/requesthandler/RequestHandler.h
@@ -151,6 +151,7 @@ private:
 	RequestResult SetSceneItemTransform(const Request &);
 	RequestResult GetSceneItemEnabled(const Request &);
 	RequestResult SetSceneItemEnabled(const Request &);
+	RequestResult ToggleSceneItemEnabled(const Request &);
 	RequestResult GetSceneItemLocked(const Request &);
 	RequestResult SetSceneItemLocked(const Request &);
 	RequestResult GetSceneItemIndex(const Request &);

--- a/src/requesthandler/RequestHandler_SceneItems.cpp
+++ b/src/requesthandler/RequestHandler_SceneItems.cpp
@@ -526,6 +526,40 @@ RequestResult RequestHandler::SetSceneItemEnabled(const Request &request)
 }
 
 /**
+ * Toggles the enable state of a scene item.
+ *
+ * Scenes and Groups
+ *
+ * @requestField sceneName        | String  | Name of the scene the item is in
+ * @requestField sceneItemId      | Number  | Numeric ID of the scene item | >= 0
+ * 
+ * @responseField sceneItemEnabled | Boolean | Whether the scene item has been enabled. `true` for enabled, `false` for disabled
+ *
+ * @requestType ToggleSceneItemEnabled
+ * @complexity 2
+ * @rpcVersion -1
+ * @initialVersion 5.3.0
+ * @api requests
+ * @category scene items
+ */
+RequestResult RequestHandler::ToggleSceneItemEnabled(const Request &request)
+{
+	RequestStatus::RequestStatus statusCode;
+	std::string comment;
+	OBSSceneItemAutoRelease sceneItem = request.ValidateSceneItem("sceneName", "sceneItemId", statusCode, comment,
+								      OBS_WEBSOCKET_SCENE_FILTER_SCENE_OR_GROUP);
+	if (!sceneItem)
+		return RequestResult::Error(statusCode, comment);
+
+	bool sceneItemEnabled = !obs_sceneitem_visible(sceneItem);
+	obs_sceneitem_set_visible(sceneItem, sceneItemEnabled);
+
+	json responseData;
+	responseData["sceneItemEnabled"] = sceneItemEnabled;
+	return RequestResult::Success(responseData);
+}
+
+/**
  * Gets the lock state of a scene item.
  *
  * Scenes and Groups


### PR DESCRIPTION
### Description
Adds a new request called `ToggleSceneItemEnabled` which toggles the enable state of a scene item and returns the new state.

### Motivation and Context
Closes #1153 

### How Has This Been Tested?
Tested OS(s): Windows 10 (22H2 19045)
New request tested with the help of `obs-websocket-js` lib

### Types of changes
- New request/event
- Documentation change (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
