### PR TITLE
Requests: Add SaveOutputScreenshot

### DIFF
--- a/src/requesthandler/RequestHandler.cpp
+++ b/src/requesthandler/RequestHandler.cpp
@@ -159,6 +159,7 @@ const std::unordered_map<std::string, RequestMethodHandler> RequestHandler::_han
 	{"StopOutput", &RequestHandler::StopOutput},
 	{"GetOutputSettings", &RequestHandler::GetOutputSettings},
 	{"SetOutputSettings", &RequestHandler::SetOutputSettings},
+	{"SaveOutputScreenshot", &RequestHandler::SaveOutputScreenshot},
 
 	// Stream
 	{"GetStreamStatus", &RequestHandler::GetStreamStatus},

--- a/src/requesthandler/RequestHandler.h
+++ b/src/requesthandler/RequestHandler.h
@@ -178,6 +178,7 @@ private:
 	RequestResult StopOutput(const Request &);
 	RequestResult GetOutputSettings(const Request &);
 	RequestResult SetOutputSettings(const Request &);
+	RequestResult SaveOutputScreenshot(const Request &);
 
 	// Stream
 	RequestResult GetStreamStatus(const Request &);

--- a/src/requesthandler/RequestHandler_Outputs.cpp
+++ b/src/requesthandler/RequestHandler_Outputs.cpp
@@ -488,3 +488,20 @@ RequestResult RequestHandler::SetOutputSettings(const Request &request)
 
 	return RequestResult::Success();
 }
+
+/**
+ * Saves a screenshot of a output to the filesystem.
+ *
+ * @requestType SaveOutputScreenshot
+ * @complexity 1
+ * @rpcVersion -1
+ * @initialVersion 5.2.3
+ * @api requests
+ * @category outputs
+ */
+RequestResult RequestHandler::SaveOutputScreenshot(const Request &)
+{
+    json responseData;
+    obs_frontend_take_screenshot();
+    return RequestResult::Success(responseData);
+}


### PR DESCRIPTION
### Description
Adds a new request called SaveOutputScreenshot which takes a screenshot of the main OBS output.

### Motivation and Context
I am currently developing a plugin that utilizes the OBS WebSocket Server. One of the essential 
commands I need to include is the ability to capture an output screenshot. This command must be 
made available in the OBS WebSocket Server.

### How Has This Been Tested?
Tested OS(s): macOS Ventura 13.4.1
Testing method: Postman
After successfully connection, I send this command:
```
{
    "op": 6,
    "d": {
        "requestType": "SaveOutputScreenshot",
        "requestId": "19b2e224-67b8-470a-a216-fc0f6a87160e"
    }
}
```
Then I received responses:
```
{
    "d": {
        "requestId": "19b2e224-67b8-470a-a216-fc0f6a87160e",
        "requestStatus": {
            "code": 100,
            "result": true
        },
        "requestType": "SaveOutputScreenshot"
    },
    "op": 7
}
```

```
{
    "d": {
        "eventData": {
            "savedScreenshotPath": "/Users/oooooo/Movies/Screenshot 2023-07-24 15-52-42.png"
        },
        "eventIntent": 1024,
        "eventType": "ScreenshotSaved"
    },
    "op": 5
}
```

### Types of changes
<!--- - New request/event (non-breaking) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x ] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [ x] All commit messages are properly formatted and commits squashed where appropriate.
-  [ x] My code is not on `master` or a `release/*` branch.
-  [ x] The code has been tested.
-  [ x] I have included updates to all appropriate documentation.
