### PR TITLE
base: Fix error to save configuration at obs_module_unload

### DIFF
--- a/src/obs-websocket.cpp
+++ b/src/obs-websocket.cpp
@@ -125,8 +125,7 @@ void obs_module_unload(void)
 	// Destroy the event handler
 	_eventHandler.reset();
 
-	// Save and destroy the config manager
-	_config->Save();
+	// Destroy the config manager
 	_config.reset();
 
 	// Destroy the cpu stats


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->

This PR removes `_config->Save()` from `obs_module_unload`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

Less number of error logs is better.

When `obs_module_unload` is called, the frontend API is no longer available so that `_config->Save()` is failing with error messages. Since the configuration is saved from the OK or the Apply button on the dialog, it is not necessary to save it again at `obs_module_unload`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Fedora 37

Run obs and exit it. Checked the log message shows no line below.
```
Tried to call obs_frontend_get_global_config with no callbacks!
[obs-websocket] [Config::Save] Unable to fetch OBS config!
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
