### PR TITLE
cmake: Update library and target names for qrcodegen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,9 @@ find_qt(COMPONENTS Core Widgets Svg Network)
 find_package(nlohmann_json 3 REQUIRED)
 
 # Find qrcodegencpp
-find_package(Libqrcodegencpp REQUIRED)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+find_package(qrcodegencpp REQUIRED)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
 
 # Find WebSocket++
 find_package(Websocketpp 0.8 REQUIRED)
@@ -151,7 +153,7 @@ target_link_libraries(
           nlohmann_json::nlohmann_json
           Websocketpp::Websocketpp
           Asio::Asio
-          Libqrcodegencpp::Libqrcodegencpp)
+          qrcodegencpp::qrcodegencpp)
 
 set_target_properties_obs(
   obs-websocket


### PR DESCRIPTION
### Description
Changes identifiers for qrcodegen to use unified identifier provided by CMake packages.

### Motivation and Context
qrcodegen is identified as such (without the "lib" prefix) and as the target "qrcodegencpp::qrcodegencpp" by the CMake package generated by obs-deps.

Requires https://github.com/obsproject/obs-deps/pull/214 to be merged and released.
Needs to be integrated into https://github.com/obsproject/obs-studio/pull/9601.

### How Has This Been Tested?
Tested by building OBS Studio with websocket support and all related changes applied.

Tested OS(s): Windows 11, macOS 13.5.2, Ubuntu 22.10

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
