### PR TITLE
cmake: Ignore LNK4099 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,4 +168,6 @@ if(OS_WINDOWS)
     TARGET obs-websocket
     APPEND
     PROPERTY AUTORCC_OPTIONS --format-version 1)
+
+  target_link_options(obs-websocket PRIVATE /IGNORE:4099)
 endif()

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -155,6 +155,7 @@ endif()
 
 if(MSVC)
   target_compile_options(obs-websocket PRIVATE /wd4267 /wd4996)
+  target_link_options(obs-websocket PRIVATE "LINKER:/IGNORE:4099")
 else()
   target_compile_options(
     obs-websocket


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
Despite building the PDBs for qrcodegencpp debug builds, we do not currently ship those PDBs, so MSVC emits an LNK4099 warning, which causes a build failure. It's unlikely that we'll need to debug in linked dependencies, so we can ignore this warning. Should we decide in the future to ship PDBs for these dependencies, the warning would no longer be emitted, and this flag would be superfluous without requiring a change. For now, let's make sure we can build in Debug.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Want to build OBS in Debug with obs-websocket enabled.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 
* Windows 11
  Built OBS in Debug with obs-websocket enabled.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
