### PR TITLE
cmake: Update library and target names for qrcodegen

### DIFF
--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -18,7 +18,9 @@ find_qt(COMPONENTS Core Widgets Svg Network)
 find_package(nlohmann_json 3 REQUIRED)
 
 # Find qrcodegencpp
-find_package(Libqrcodegencpp REQUIRED)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+find_package(qrcodegencpp REQUIRED)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
 
 # Find WebSocket++
 find_package(Websocketpp 0.8 REQUIRED)
@@ -138,7 +140,7 @@ target_link_libraries(
           nlohmann_json::nlohmann_json
           Websocketpp::Websocketpp
           Asio::Asio
-          Libqrcodegencpp::Libqrcodegencpp)
+          qrcodegencpp::qrcodegencpp)
 
 target_compile_features(obs-websocket PRIVATE cxx_std_17)
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
qrcodegen is identified as such (without the "lib" prefix) and as the target "qrcodegencpp::qrcodegencpp" by the CMake package generated by obs-deps and the finders in obs-studio when using module fallback.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Want OBS Studio to build in Debug without issues. This is a follow-up to #1167.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 
* Windows 11
  Tested using the updated finder at https://github.com/obsproject/obs-studio/pull/9601 for non-Debug builds to ensure the finder itself still works. The finder shouldn't be invoked on Windows in the end.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
