### PR TITLE
CI: Possible bugfix for the Status Duration. Please Test.

### DIFF
--- a/src/forms/SettingsDialog.cpp
+++ b/src/forms/SettingsDialog.cpp
@@ -231,7 +231,7 @@ void SettingsDialog::FillSessionTable()
 		ui->websocketSessionTable->setItem(i, 0, addressItem);
 
 		uint64_t sessionDuration = QDateTime::currentSecsSinceEpoch().addSecs(-session.connectedAt);
-		QTableWidgetItem *durationItem = new QTableWidgetItem(QTime((int) sessionDuration / 86400, (int) sessionDuration / 360, sessionDuration % 60, 0).toString("hh:mm:ss"));
+		QTableWidgetItem *durationItem = new QTableWidgetItem(QTime((int) sessionDuration / 3600, (int) sessionDuration / 360, sessionDuration % 60, 0).toString("hh:mm:ss"));
 		ui->websocketSessionTable->setItem(i, 1, durationItem);
 
 		QTableWidgetItem *statsItem =

--- a/src/forms/SettingsDialog.cpp
+++ b/src/forms/SettingsDialog.cpp
@@ -230,8 +230,8 @@ void SettingsDialog::FillSessionTable()
 		QTableWidgetItem *addressItem = new QTableWidgetItem(QString::fromStdString(session.remoteAddress));
 		ui->websocketSessionTable->setItem(i, 0, addressItem);
 
-		uint64_t sessionDuration = QDateTime::currentSecsSinceEpoch() - session.connectedAt;
-		QTableWidgetItem *durationItem = new QTableWidgetItem(QTime(0, 0, sessionDuration).toString("hh:mm:ss"));
+		uint64_t sessionDuration = QDateTime::currentSecsSinceEpoch().addSecs(-session.connectedAt);
+		QTableWidgetItem *durationItem = new QTableWidgetItem(QTime((int) sessionDuration / 86400, (int) sessionDuration / 360, sessionDuration % 60, 0).toString("hh:mm:ss"));
 		ui->websocketSessionTable->setItem(i, 1, durationItem);
 
 		QTableWidgetItem *statsItem =


### PR DESCRIPTION
from https://doc.qt.io/qt-6/qtime.html#fromString

QTime::QTime(int h, int m, int s = 0, int ms = 0)

Constructs a time with hour h, minute m, seconds s and milliseconds ms.

h must be in the range 0 to 23, m and s must be in the range 0 to 59, and ms must be in the range 0 to 999.

### Description
Changes the way the "Status Duration" is implemented

### Motivation and Context
It hopefully fixes the "Status Duration" disappering after 59 seconds

### How Has This Been Tested?
Has not been.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
-  [ x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [ ] All commit messages are properly formatted and commits squashed where appropriate.
-  [ ] My code is not on `master` or a `release/*` branch.
-  [ ] The code has been tested.
-  [ ] I have included updates to all appropriate documentation.
