### PR TITLE
requesthandler: Add optional context to TriggerHotkeyByName

### DIFF
--- a/src/requesthandler/RequestHandler_General.cpp
+++ b/src/requesthandler/RequestHandler_General.cpp
@@ -233,6 +233,7 @@ RequestResult RequestHandler::GetHotkeyList(const Request &)
  * Triggers a hotkey using its name. See `GetHotkeyList`
  *
  * @requestField hotkeyName | String | Name of the hotkey to trigger
+ * @requestField ?contextName | String | Name of context of the hotkey to trigger
  *
  * @requestType TriggerHotkeyByName
  * @complexity 3
@@ -248,7 +249,15 @@ RequestResult RequestHandler::TriggerHotkeyByName(const Request &request)
 	if (!request.ValidateString("hotkeyName", statusCode, comment))
 		return RequestResult::Error(statusCode, comment);
 
-	obs_hotkey_t *hotkey = Utils::Obs::SearchHelper::GetHotkeyByName(request.RequestData["hotkeyName"]);
+	std::string contextName;
+	if (request.Contains("contextName")) {
+		if (!request.ValidateOptionalString("contextName", statusCode, comment))
+			return RequestResult::Error(statusCode, comment);
+
+		contextName = request.RequestData["contextName"];
+	}
+
+	obs_hotkey_t *hotkey = Utils::Obs::SearchHelper::GetHotkeyByName(request.RequestData["hotkeyName"], contextName);
 	if (!hotkey)
 		return RequestResult::Error(RequestStatus::ResourceNotFound, "No hotkeys were found by that name.");
 

--- a/src/utils/Obs.h
+++ b/src/utils/Obs.h
@@ -297,7 +297,7 @@ namespace Utils {
 		}
 
 		namespace SearchHelper {
-			obs_hotkey_t *GetHotkeyByName(std::string name);
+			obs_hotkey_t *GetHotkeyByName(std::string name, std::string context);
 			obs_source_t *GetSceneTransitionByName(std::string name); // Increments source ref. Use OBSSourceAutoRelease
 			obs_sceneitem_t *GetSceneItemByName(obs_scene_t *scene, std::string name,
 							    int offset = 0); // Increments ref. Use OBSSceneItemAutoRelease


### PR DESCRIPTION
### Description
Add optional context to TriggerHotkeyByName

### Motivation and Context
The same hotkey name can exist on multiple context, to make sure we got the correct one add an optional context

### How Has This Been Tested?
Tried calling 
`{
  "requestType": "TriggerHotkeyByName",
  "requestData": {
    "hotkeyName": "OBSBasic.SelectScene",
    "contextName": "Scene 1"
  }
}`
Tested OS(s): Windows 11

### Types of changes
 - New request/event (non-breaking) 
 
### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
