### PR TITLE
docs: Fix SaveSourceScreenshot's Response Field

### DIFF
--- a/src/requesthandler/RequestHandler_Sources.cpp
+++ b/src/requesthandler/RequestHandler_Sources.cpp
@@ -245,8 +245,6 @@ RequestResult RequestHandler::GetSourceScreenshot(const Request &request)
  * @requestField ?imageHeight             | Number | Height to scale the screenshot to                                                                                        | >= 8, <= 4096 | Source value is used
  * @requestField ?imageCompressionQuality | Number | Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk) | >= -1, <= 100 | -1
  *
- * @responseField imageData | String | Base64-encoded screenshot
- *
  * @requestType SaveSourceScreenshot
  * @complexity 3
  * @rpcVersion -1


### PR DESCRIPTION
### Description

Fixed incorrect response field in SaveSourceScreenshot.
SaveSourceScreenshot returns None.

### Motivation and Context

This PR fixes #991

### How Has This Been Tested?

N/A

### Types of changes

 Documentation change (a change to documentation pages) 

### Checklist:

-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
