### PR TITLE
cmake,lib,base: Export obs-websocket-api as a target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ legacy_check()
 set(obs-websocket_VERSION 5.4.2)
 set(OBS_WEBSOCKET_RPC_VERSION 1)
 
+include(cmake/obs-websocket-api.cmake)
+
 option(ENABLE_WEBSOCKET "Enable building OBS with websocket plugin" ON)
 if(NOT ENABLE_WEBSOCKET)
   target_disable(obs-websocket)
@@ -34,7 +36,6 @@ add_library(OBS::websocket ALIAS obs-websocket)
 target_sources(
   obs-websocket
   PRIVATE # cmake-format: sortable
-          lib/obs-websocket-api.h
           src/Config.cpp
           src/Config.h
           src/forms/ConnectInfo.cpp
@@ -154,6 +155,7 @@ target_link_libraries(
   obs-websocket
   PRIVATE OBS::libobs
           OBS::frontend-api
+          OBS::websocket-api
           Qt::Core
           Qt::Widgets
           Qt::Svg

--- a/cmake/legacy.cmake
+++ b/cmake/legacy.cmake
@@ -3,6 +3,21 @@ set(OBS_WEBSOCKET_RPC_VERSION 1)
 
 option(ENABLE_WEBSOCKET "Enable building OBS with websocket plugin" ON)
 
+add_library(obs-websocket-api INTERFACE)
+add_library(OBS::websocket-api ALIAS obs-websocket-api)
+
+target_sources(obs-websocket-api INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/obs-websocket-api.h>
+                                           $<INSTALL_INTERFACE:${OBS_INCLUDE_DESTINATION}/obs-websocket-api.h>)
+
+target_link_libraries(obs-websocket-api INTERFACE OBS::libobs)
+
+target_include_directories(obs-websocket-api INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib>
+                                                       $<INSTALL_INTERFACE:${OBS_INCLUDE_DESTINATION}>)
+
+set_target_properties(obs-websocket-api PROPERTIES PUBLIC_HEADER lib/obs-websocket-api.h)
+
+export_target(obs-websocket-api)
+
 if(NOT ENABLE_WEBSOCKET OR NOT ENABLE_UI)
   message(STATUS "OBS:  DISABLED   obs-websocket")
   return()
@@ -56,7 +71,6 @@ target_sources(
           src/obs-websocket.h
           src/Config.cpp
           src/Config.h
-          lib/obs-websocket-api.h
           src/forms/SettingsDialog.cpp
           src/forms/SettingsDialog.h
           src/forms/ConnectInfo.cpp
@@ -133,6 +147,7 @@ target_link_libraries(
   obs-websocket
   PRIVATE OBS::libobs
           OBS::frontend-api
+          OBS::websocket-api
           Qt::Core
           Qt::Widgets
           Qt::Svg

--- a/cmake/obs-websocket-api.cmake
+++ b/cmake/obs-websocket-api.cmake
@@ -1,0 +1,14 @@
+add_library(obs-websocket-api INTERFACE)
+add_library(OBS::websocket-api ALIAS obs-websocket-api)
+
+target_sources(obs-websocket-api INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib/obs-websocket-api.h>
+                                           $<INSTALL_INTERFACE:${OBS_INCLUDE_DESTINATION}/obs-websocket-api.h>)
+
+target_link_libraries(obs-websocket-api INTERFACE OBS::libobs)
+
+target_include_directories(obs-websocket-api INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib>"
+                                                       "$<INSTALL_INTERFACE:${OBS_INCLUDE_DESTINATION}>")
+
+set_target_properties(obs-websocket-api PROPERTIES PREFIX "" PUBLIC_HEADER lib/obs-websocket-api.h)
+
+target_export(obs-websocket-api)

--- a/cmake/obs-websocket-apiConfig.cmake.in
+++ b/cmake/obs-websocket-apiConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(libobs REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/src/WebSocketApi.h
+++ b/src/WebSocketApi.h
@@ -24,8 +24,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <mutex>
 #include <shared_mutex>
 #include <obs.h>
-
-#include "../lib/obs-websocket-api.h"
+#include <obs-websocket-api.h>
 
 class WebSocketApi {
 public:


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->

Relies on:
- https://github.com/obsproject/obs-studio/pull/10100

This enables the installation of the header in the include directory by exporting it as an interface target

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

No more copy-pasting the header to use it

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 
- Arch Linux

Windows and macOS headers needs to be checked
- Tested on Windows,  `--component Development` adds the header

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
- Other Enhancement (anything not applicable to what is listed)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
