### PR TITLE
CI: Update first-party GitHub Actions to v4

### DIFF
--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository_owner == 'obsproject'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 100
       - name: Upload US English Language Files 🇺🇸

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -18,7 +18,7 @@ jobs:
       IS_CI: "true"
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ${{ github.workspace }}/obs-websocket
       - name: 'Generate docs'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     if: contains(github.event.head_commit.message, '[skip ci]') != true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Generate docs
         run: cd docs && ./build_docs.sh
       - name: Run markdownlint-cli


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
CI: Update first-party GitHub Actions to v4

GitHub Actions has deprecated actions based on node16. The v4 actions are based on node20. Replace first-party v2/v3 actions with their v4 counterparts.

GitHub Actions has deprecated actions based on node12 and forces them to run on node16, which is also deprecated. Update to v4 actions to avoid warnings on CI.

See:
* https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
* https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Want less CI warnings and don't want CI to stop working when node12/node16 are disabled.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
This is on CI. obs-deps, obs-studio, obs-browser, and obs-plugintemplate have had successful runs with updated first-party actions.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
- Other Enhancement (anything not applicable to what is listed)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [ ] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
