### PR TITLE
requesthandler: Add `cropToBounds` to scene item

### DIFF
--- a/src/requesthandler/RequestHandler_SceneItems.cpp
+++ b/src/requesthandler/RequestHandler_SceneItems.cpp
@@ -502,6 +502,13 @@ RequestResult RequestHandler::SetSceneItemTransform(const Request &request)
 		cropChanged = true;
 	}
 
+	if (r.Contains("cropToBounds")) {
+		if (!r.ValidateOptionalBoolean("cropToBounds", statusCode, comment))
+			return RequestResult::Error(statusCode, comment);
+		sceneItemTransform.crop_to_bounds = r.RequestData["cropToBounds"];
+		transformChanged = true;
+	}
+
 	if (!transformChanged && !cropChanged)
 		return RequestResult::Error(RequestStatus::CannotAct, "You have not provided any valid transform changes.");
 

--- a/src/utils/Obs_ObjectHelper.cpp
+++ b/src/utils/Obs_ObjectHelper.cpp
@@ -83,5 +83,7 @@ json Utils::Obs::ObjectHelper::GetSceneItemTransform(obs_sceneitem_t *item)
 	ret["cropTop"] = (int)crop.top;
 	ret["cropBottom"] = (int)crop.bottom;
 
+	ret["cropToBounds"] = osi.crop_to_bounds;
+
 	return ret;
 }


### PR DESCRIPTION
### Description
Add `cropToBounds` to scene item

### Motivation and Context
Was added in obs, but not in obs-websocket yet
The new `obs_sceneitem_set_info2` is used but `crop_to_bounds` is not set

### How Has This Been Tested?
On windows 11 by getting and setting

### Types of changes
- New request/event (non-breaking) 

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
