### PR TITLE
requesthandler: Fix releasing hotkeys triggered by name

### DIFF
--- a/src/requesthandler/RequestHandler_General.cpp
+++ b/src/requesthandler/RequestHandler_General.cpp
@@ -266,6 +266,7 @@ RequestResult RequestHandler::TriggerHotkeyByName(const Request &request)
 		return RequestResult::Error(RequestStatus::ResourceNotFound, "No hotkeys were found by that name.");
 
 	obs_hotkey_trigger_routed_callback(obs_hotkey_get_id(hotkey), true);
+	obs_hotkey_trigger_routed_callback(obs_hotkey_get_id(hotkey), false);
 
 	return RequestResult::Success();
 }


### PR DESCRIPTION
### Description
Fix releasing hotkeys triggered by name

### Motivation and Context
Hotkey pairs require the other hotkey to be released before it can be pressed.
It is done for `TriggerHotkeyByKeySequence`, but not for `TriggerHotkeyByName`

### How Has This Been Tested?
by calling both hotkeys of an hotkey pair with `TriggerHotkeyByName`
Tested OS(s): 
Windows 11

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
