### PR TITLE
Config: Ensure conversion to filesystem::path uses utf-8

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -193,7 +193,7 @@ bool MigratePersistentData()
 	std::error_code ec;
 
 	// Ensure module config directory exists
-	std::string moduleConfigDirectory = Utils::Obs::StringHelper::GetModuleConfigPath("");
+	auto moduleConfigDirectory = std::filesystem::u8path(Utils::Obs::StringHelper::GetModuleConfigPath(""));
 	if (!std::filesystem::exists(moduleConfigDirectory, ec))
 		std::filesystem::create_directories(moduleConfigDirectory, ec);
 	if (ec) {
@@ -203,10 +203,11 @@ bool MigratePersistentData()
 	}
 
 	// Move any existing persistent data to module config directory, then delete old file
-	std::string oldPersistentDataPath =
-		Utils::Obs::StringHelper::GetCurrentProfilePath() + "/../../../obsWebSocketPersistentData.json";
+	auto oldPersistentDataPath = std::filesystem::u8path(Utils::Obs::StringHelper::GetCurrentProfilePath() +
+							     "/../../../obsWebSocketPersistentData.json");
 	if (std::filesystem::exists(oldPersistentDataPath, ec)) {
-		std::string persistentDataPath = Utils::Obs::StringHelper::GetModuleConfigPath("persistent_data.json");
+		auto persistentDataPath =
+			std::filesystem::u8path(Utils::Obs::StringHelper::GetModuleConfigPath("persistent_data.json"));
 		std::filesystem::copy_file(oldPersistentDataPath, persistentDataPath, ec);
 		std::filesystem::remove(oldPersistentDataPath, ec);
 		blog(LOG_INFO, "[MigratePersistentData] Persistent data migrated to new path");


### PR DESCRIPTION
### Description

Use `u8path` to construct the `std::filesystem::path` to ensure the string is correctly treated as UTF-8.

### Motivation and Context

Fixes crash on startup if OBS is installed on non-English systems.

### How Has This Been Tested?

Tested on a Windows VM with a user named `くそ`, while I could not reproduce the crash, I could reproduce the plugin not loading due to the migration failing. With this patch it worked and loaded up normally.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
