### PR TITLE
On Show Connect apply/save settings to prevent Info dialog being stale

### DIFF
--- a/src/forms/SettingsDialog.cpp
+++ b/src/forms/SettingsDialog.cpp
@@ -300,6 +300,9 @@ void SettingsDialog::ShowConnectInfoButtonClicked()
 		}
 	}
 
+	// show connect info implies apply to prevent outdata data on a missed apply
+	SaveFormData();
+
 	connectInfo->show();
 	connectInfo->activateWindow();
 	connectInfo->raise();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description

On [Show Connect Info] Apply/save the form

I misfiled: https://github.com/obsproject/obs-studio/issues/10947 so this fixes #1236 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

A user could change one of the values (notably the generate new random password) hit show connect info and show the previous auto generated password and not the new one if the user didn't hit apply before show.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

Added one line to save when show connect is hit

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [ ] The code has been tested.
-  [x] I have included updates to all appropriate documentation.

Not tested as outside of my skillset persae