### PR TITLE
Architecture: adding windows on ARM support

### DIFF
--- a/src/requesthandler/RequestHandler_SceneItems.cpp
+++ b/src/requesthandler/RequestHandler_SceneItems.cpp
@@ -440,7 +440,7 @@ RequestResult RequestHandler::SetSceneItemTransform(const Request &request)
 	}
 
 	if (r.Contains("alignment")) {
-		if (!r.ValidateOptionalNumber("alignment", statusCode, comment, 0, std::numeric_limits<uint32_t>::max()))
+		if (!r.ValidateOptionalNumber("alignment", statusCode, comment, 0, (std::numeric_limits<uint32_t>::max)()))
 			return RequestResult::Error(statusCode, comment);
 		sceneItemTransform.alignment = r.RequestData["alignment"];
 		transformChanged = true;
@@ -458,7 +458,7 @@ RequestResult RequestHandler::SetSceneItemTransform(const Request &request)
 	}
 
 	if (r.Contains("boundsAlignment")) {
-		if (!r.ValidateOptionalNumber("boundsAlignment", statusCode, comment, 0, std::numeric_limits<uint32_t>::max()))
+		if (!r.ValidateOptionalNumber("boundsAlignment", statusCode, comment, 0, (std::numeric_limits<uint32_t>::max)()))
 			return RequestResult::Error(statusCode, comment);
 		sceneItemTransform.bounds_alignment = r.RequestData["boundsAlignment"];
 		transformChanged = true;


### PR DESCRIPTION
<!--Introduces Windows on ARM support to the OBS-Websocket. This includes modifications that are guarded with ARM-specific macros to ensure compatibility without affecting the existing codebase. -->

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
This pull request introduces Windows on ARM support for the OBS-WebSocket. The changes include modifications which are carefully guarded with ARM-specific macros to ensure compatibility without affecting the existing codebase.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
The primary motivation for this change is to expand the compatibility of OBS Studio to include Windows on ARM-based systems. This enhancement allows users running on ARM architecture to leverage the functionalities of OBS-WebSocket. By ensuring that changes are guarded with ARM-specific macros, we maintain the integrity and compatibility of the existing codebase. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): Windows 11

The changes were tested by building the OBS Studio application on an ARM machine (X-Elite machine). All builds were successful. Basic functionality tests confirmed that the OBS Studio application with the modified WebSocket is functional.

### Types of changes
#### Code Refactoring:

- Replaces "std::numeric_limits<uint32_t>::max()" with "(std::numeric_limits<uint32_t>::max)()" to avoid conflicts with macros named "max" in certain environments.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
