### PR TITLE
cmake: Downgrade deprecation error for GCC compilations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ target_compile_options(
           $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-error=format-overflow>
           $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-error=int-conversion>
           $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-error=comment>
+          $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-error=deprecated-declarations>
           $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-error=null-pointer-subtraction>
           $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-error=deprecated-declarations>
           $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-error=implicit-int-conversion>


### PR DESCRIPTION
### Description
Downgrades the deprecated declarations error to warnings for GCC compilations in line with Clang and AppleClang.

### Motivation and Context
Error has already been downgraded for Clang and AppleClang, not doing so for GCC was an oversight.

### How Has This Been Tested?
Tested OS(s): Ubuntu 24.04

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
