### PR TITLE
cmake: Downgrade deprecation error for MSVC compilations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ target_compile_definitions(
 target_compile_options(
   obs-websocket
   PRIVATE $<$<PLATFORM_ID:Windows>:/wd4267>
+          $<$<PLATFORM_ID:Windows>:/wd4996>
           $<$<COMPILE_LANG_AND_ID:CXX,GNU,AppleClang,Clang>:-Wall>
           $<$<COMPILE_LANG_AND_ID:CXX,GNU,AppleClang,Clang>:-Wno-error=float-conversion>
           $<$<COMPILE_LANG_AND_ID:CXX,GNU,AppleClang,Clang>:-Wno-error=shadow>


### PR DESCRIPTION
### Description
Downgrades the error for use of deprecated declarations to a warning on Windows. Follow-up PR to #1241.

### Motivation and Context
Error has already been downgraded for Clang, AppleClang, and GCC.

### How Has This Been Tested?
Tested OS(s): Windows 11

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
