### PR TITLE
Add specific types of `number`

### DIFF
--- a/docs/docs/process_comments.py
+++ b/docs/docs/process_comments.py
@@ -47,7 +47,7 @@ def get_request_fields(fields):
 
         valueOptionalOffset = 3
         # If value type is a number, restrictions are required. Else, should not be added.
-        if field_out['valueType'].lower() == 'number':
+        if field_out['valueType'].lower().startswith('number'):
             # In the case of a number, the optional component gets pushed back.
             valueOptionalOffset += 1
             field_out['valueRestrictions'] = components[3] if components[3].lower() != 'none' else None

--- a/docs/generated/protocol.json
+++ b/docs/generated/protocol.json
@@ -1082,32 +1082,32 @@
       "responseFields": [
         {
           "valueName": "fpsNumerator",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Numerator of the fractional FPS value"
         },
         {
           "valueName": "fpsDenominator",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Denominator of the fractional FPS value"
         },
         {
           "valueName": "baseWidth",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Width of the base (canvas) resolution in pixels"
         },
         {
           "valueName": "baseHeight",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Height of the base (canvas) resolution in pixels"
         },
         {
           "valueName": "outputWidth",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Width of the output resolution in pixels"
         },
         {
           "valueName": "outputHeight",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Height of the output resolution in pixels"
         }
       ]
@@ -1123,7 +1123,7 @@
       "requestFields": [
         {
           "valueName": "fpsNumerator",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Numerator of the fractional FPS value",
           "valueRestrictions": ">= 1",
           "valueOptional": true,
@@ -1131,7 +1131,7 @@
         },
         {
           "valueName": "fpsDenominator",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Denominator of the fractional FPS value",
           "valueRestrictions": ">= 1",
           "valueOptional": true,
@@ -1139,7 +1139,7 @@
         },
         {
           "valueName": "baseWidth",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Width of the base (canvas) resolution in pixels",
           "valueRestrictions": ">= 1, <= 4096",
           "valueOptional": true,
@@ -1147,7 +1147,7 @@
         },
         {
           "valueName": "baseHeight",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Height of the base (canvas) resolution in pixels",
           "valueRestrictions": ">= 1, <= 4096",
           "valueOptional": true,
@@ -1155,7 +1155,7 @@
         },
         {
           "valueName": "outputWidth",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Width of the output resolution in pixels",
           "valueRestrictions": ">= 1, <= 4096",
           "valueOptional": true,
@@ -1163,7 +1163,7 @@
         },
         {
           "valueName": "outputHeight",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Height of the output resolution in pixels",
           "valueRestrictions": ">= 1, <= 4096",
           "valueOptional": true,
@@ -1560,7 +1560,7 @@
         },
         {
           "valueName": "filterIndex",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "New index position of the filter",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -1724,57 +1724,57 @@
       "responseFields": [
         {
           "valueName": "cpuUsage",
-          "valueType": "Number",
+          "valueType": "Number(double)",
           "valueDescription": "Current CPU usage in percent"
         },
         {
           "valueName": "memoryUsage",
-          "valueType": "Number",
+          "valueType": "Number(double)",
           "valueDescription": "Amount of memory in MB currently being used by OBS"
         },
         {
           "valueName": "availableDiskSpace",
-          "valueType": "Number",
+          "valueType": "Number(double)",
           "valueDescription": "Available disk space on the device being used for recording storage"
         },
         {
           "valueName": "activeFps",
-          "valueType": "Number",
+          "valueType": "Number(double)",
           "valueDescription": "Current FPS being rendered"
         },
         {
           "valueName": "averageFrameRenderTime",
-          "valueType": "Number",
+          "valueType": "Number(double)",
           "valueDescription": "Average time in milliseconds that OBS is taking to render a frame"
         },
         {
           "valueName": "renderSkippedFrames",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Number of frames skipped by OBS in the render thread"
         },
         {
           "valueName": "renderTotalFrames",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Total number of frames outputted by the render thread"
         },
         {
           "valueName": "outputSkippedFrames",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Number of frames skipped by OBS in the output thread"
         },
         {
           "valueName": "outputTotalFrames",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Total number of frames outputted by the output thread"
         },
         {
           "valueName": "webSocketSessionIncomingMessages",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Total number of messages received by obs-websocket from the client"
         },
         {
           "valueName": "webSocketSessionOutgoingMessages",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Total number of messages sent by obs-websocket to the client"
         }
       ]
@@ -1967,7 +1967,7 @@
       "requestFields": [
         {
           "valueName": "sleepMillis",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode)",
           "valueRestrictions": ">= 0, <= 50000",
           "valueOptional": true,
@@ -1975,7 +1975,7 @@
         },
         {
           "valueName": "sleepFrames",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Number of frames to sleep for (if `SERIAL_FRAME` mode)",
           "valueRestrictions": ">= 0, <= 10000",
           "valueOptional": true,
@@ -2144,7 +2144,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "ID of the newly created scene item"
         }
       ]
@@ -2455,12 +2455,12 @@
       "responseFields": [
         {
           "valueName": "inputVolumeMul",
-          "valueType": "Number",
+          "valueType": "Number(float)",
           "valueDescription": "Volume setting in mul"
         },
         {
           "valueName": "inputVolumeDb",
-          "valueType": "Number",
+          "valueType": "Number(float)",
           "valueDescription": "Volume setting in dB"
         }
       ]
@@ -2492,7 +2492,7 @@
         },
         {
           "valueName": "inputVolumeMul",
-          "valueType": "Number",
+          "valueType": "Number(float)",
           "valueDescription": "Volume setting in mul",
           "valueRestrictions": ">= 0, <= 20",
           "valueOptional": true,
@@ -2500,7 +2500,7 @@
         },
         {
           "valueName": "inputVolumeDb",
-          "valueType": "Number",
+          "valueType": "Number(float)",
           "valueDescription": "Volume setting in dB",
           "valueRestrictions": ">= -100, <= 26",
           "valueOptional": true,
@@ -2538,7 +2538,7 @@
       "responseFields": [
         {
           "valueName": "inputAudioBalance",
-          "valueType": "Number",
+          "valueType": "Number(float)",
           "valueDescription": "Audio balance value from 0.0-1.0"
         }
       ]
@@ -2570,7 +2570,7 @@
         },
         {
           "valueName": "inputAudioBalance",
-          "valueType": "Number",
+          "valueType": "Number(float)",
           "valueDescription": "New audio balance value",
           "valueRestrictions": ">= 0.0, <= 1.0",
           "valueOptional": false,
@@ -2608,7 +2608,7 @@
       "responseFields": [
         {
           "valueName": "inputAudioSyncOffset",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Audio sync offset in milliseconds"
         }
       ]
@@ -2640,7 +2640,7 @@
         },
         {
           "valueName": "inputAudioSyncOffset",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "New audio sync offset in milliseconds",
           "valueRestrictions": ">= -950, <= 20000",
           "valueOptional": false,
@@ -2901,12 +2901,12 @@
         },
         {
           "valueName": "mediaDuration",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Total duration of the playing media in milliseconds. `null` if not playing"
         },
         {
           "valueName": "mediaCursor",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Position of the cursor in milliseconds. `null` if not playing"
         }
       ]
@@ -2938,7 +2938,7 @@
         },
         {
           "valueName": "mediaCursor",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "New cursor position to set",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -2974,7 +2974,7 @@
         },
         {
           "valueName": "mediaCursorOffset",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Value to offset the current cursor position by",
           "valueRestrictions": null,
           "valueOptional": false,
@@ -3606,7 +3606,7 @@
         },
         {
           "valueName": "searchOffset",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Number of matches to skip during search. >= 0 means first forward. -1 means last (top) item",
           "valueRestrictions": ">= -1",
           "valueOptional": true,
@@ -3616,7 +3616,7 @@
       "responseFields": [
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item"
         }
       ]
@@ -3648,7 +3648,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -3721,7 +3721,7 @@
       "responseFields": [
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item"
         }
       ]
@@ -3753,7 +3753,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -3789,7 +3789,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -3815,7 +3815,7 @@
       "responseFields": [
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the duplicated scene item"
         }
       ]
@@ -3847,7 +3847,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -3889,7 +3889,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -3933,7 +3933,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -3975,7 +3975,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -4019,7 +4019,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -4061,7 +4061,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -4105,7 +4105,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -4115,7 +4115,7 @@
       "responseFields": [
         {
           "valueName": "sceneItemIndex",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Index position of the scene item"
         }
       ]
@@ -4147,7 +4147,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -4155,7 +4155,7 @@
         },
         {
           "valueName": "sceneItemIndex",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "New index position of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -4191,7 +4191,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -4233,7 +4233,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item",
           "valueRestrictions": ">= 0",
           "valueOptional": false,
@@ -4548,7 +4548,7 @@
         },
         {
           "valueName": "transitionDuration",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Duration of the overridden scene transition, else `null`"
         }
       ]
@@ -4588,7 +4588,7 @@
         },
         {
           "valueName": "transitionDuration",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Duration to use for any overridden transition. Specify `null` to remove",
           "valueRestrictions": ">= 50, <= 20000",
           "valueOptional": true,
@@ -4671,7 +4671,7 @@
         },
         {
           "valueName": "imageWidth",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Width to scale the screenshot to",
           "valueRestrictions": ">= 8, <= 4096",
           "valueOptional": true,
@@ -4679,7 +4679,7 @@
         },
         {
           "valueName": "imageHeight",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Height to scale the screenshot to",
           "valueRestrictions": ">= 8, <= 4096",
           "valueOptional": true,
@@ -4687,7 +4687,7 @@
         },
         {
           "valueName": "imageCompressionQuality",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use \"default\" (whatever that means, idk)",
           "valueRestrictions": ">= -1, <= 100",
           "valueOptional": true,
@@ -4745,7 +4745,7 @@
         },
         {
           "valueName": "imageWidth",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Width to scale the screenshot to",
           "valueRestrictions": ">= 8, <= 4096",
           "valueOptional": true,
@@ -4753,7 +4753,7 @@
         },
         {
           "valueName": "imageHeight",
-          "valueType": "Number",
+          "valueType": "Number(uint32)",
           "valueDescription": "Height to scale the screenshot to",
           "valueRestrictions": ">= 8, <= 4096",
           "valueOptional": true,
@@ -4761,7 +4761,7 @@
         },
         {
           "valueName": "imageCompressionQuality",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use \"default\" (whatever that means, idk)",
           "valueRestrictions": ">= -1, <= 100",
           "valueOptional": true,
@@ -5008,7 +5008,7 @@
       "requestFields": [
         {
           "valueName": "transitionDuration",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Duration in milliseconds",
           "valueRestrictions": ">= 50, <= 20000",
           "valueOptional": false,
@@ -5057,7 +5057,7 @@
       "responseFields": [
         {
           "valueName": "transitionCursor",
-          "valueType": "Number",
+          "valueType": "Number(float)",
           "valueDescription": "Cursor position, between 0.0 and 1.0"
         }
       ]
@@ -5258,7 +5258,7 @@
         },
         {
           "valueName": "monitorIndex",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Monitor index, use `GetMonitorList` to obtain index",
           "valueRestrictions": null,
           "valueOptional": true,
@@ -5302,7 +5302,7 @@
         },
         {
           "valueName": "monitorIndex",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Monitor index, use `GetMonitorList` to obtain index",
           "valueRestrictions": null,
           "valueOptional": true,
@@ -5472,7 +5472,7 @@
         },
         {
           "valueName": "filterIndex",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Index position of the filter"
         },
         {
@@ -5822,12 +5822,12 @@
         },
         {
           "valueName": "inputVolumeMul",
-          "valueType": "Number",
+          "valueType": "Number(double)",
           "valueDescription": "New volume level multiplier"
         },
         {
           "valueName": "inputVolumeDb",
-          "valueType": "Number",
+          "valueType": "Number(double)",
           "valueDescription": "New volume level in dB"
         }
       ]
@@ -5854,7 +5854,7 @@
         },
         {
           "valueName": "inputAudioBalance",
-          "valueType": "Number",
+          "valueType": "Number(float)",
           "valueDescription": "New audio balance value of the input"
         }
       ]
@@ -5881,7 +5881,7 @@
         },
         {
           "valueName": "inputAudioSyncOffset",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "New sync offset in milliseconds"
         }
       ]
@@ -6187,12 +6187,12 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item"
         },
         {
           "valueName": "sceneItemIndex",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Index position of the item"
         }
       ]
@@ -6229,7 +6229,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item"
         }
       ]
@@ -6374,7 +6374,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item"
         },
         {
@@ -6560,7 +6560,7 @@
       "dataFields": [
         {
           "valueName": "transitionDuration",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Transition duration in milliseconds"
         }
       ]

--- a/docs/generated/protocol.json
+++ b/docs/generated/protocol.json
@@ -1510,7 +1510,7 @@
         },
         {
           "valueName": "filterIndex",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Index of the filter in the list, beginning at 0"
         },
         {
@@ -1687,7 +1687,7 @@
         },
         {
           "valueName": "rpcVersion",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Current latest obs-websocket RPC version"
         },
         {
@@ -3212,22 +3212,22 @@
         },
         {
           "valueName": "outputDuration",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Current duration in milliseconds for the output"
         },
         {
           "valueName": "outputCongestion",
-          "valueType": "Number",
+          "valueType": "Number(float)",
           "valueDescription": "Congestion of the output"
         },
         {
           "valueName": "outputBytes",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Number of bytes sent by the output"
         },
         {
           "valueName": "outputSkippedFrames",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Number of frames skipped by the output's process"
         },
         {
@@ -3384,12 +3384,12 @@
         },
         {
           "valueName": "outputDuration",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Current duration in milliseconds for the output"
         },
         {
           "valueName": "outputBytes",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Number of bytes sent by the output"
         }
       ]
@@ -4797,27 +4797,27 @@
         },
         {
           "valueName": "outputDuration",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Current duration in milliseconds for the output"
         },
         {
           "valueName": "outputCongestion",
-          "valueType": "Number",
+          "valueType": "Number(float)",
           "valueDescription": "Congestion of the output"
         },
         {
           "valueName": "outputBytes",
-          "valueType": "Number",
+          "valueType": "Number(uint64)",
           "valueDescription": "Number of bytes sent by the output"
         },
         {
           "valueName": "outputSkippedFrames",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Number of frames skipped by the output's process"
         },
         {
           "valueName": "outputTotalFrames",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Total number of frames delivered by the output's process"
         }
       ]
@@ -4962,7 +4962,7 @@
         },
         {
           "valueName": "transitionDuration",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Configured transition duration in milliseconds. `null` if transition is fixed"
         },
         {
@@ -5084,7 +5084,7 @@
       "requestFields": [
         {
           "valueName": "position",
-          "valueType": "Number",
+          "valueType": "Number(float)",
           "valueDescription": "New position",
           "valueRestrictions": ">= 0.0, <= 1.0",
           "valueOptional": false,
@@ -6283,7 +6283,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item"
         },
         {
@@ -6315,7 +6315,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item"
         },
         {
@@ -6347,7 +6347,7 @@
         },
         {
           "valueName": "sceneItemId",
-          "valueType": "Number",
+          "valueType": "Number(int64)",
           "valueDescription": "Numeric ID of the scene item"
         }
       ]

--- a/docs/generated/protocol.json
+++ b/docs/generated/protocol.json
@@ -3232,7 +3232,7 @@
         },
         {
           "valueName": "outputTotalFrames",
-          "valueType": "Number",
+          "valueType": "Number(int32)",
           "valueDescription": "Total number of frames delivered by the output's process"
         }
       ]

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -1964,8 +1964,8 @@ An input's volume level has changed.
 | ---- | :---: | ----------- |
 | inputName | String | Name of the input |
 | inputUuid | String | UUID of the input |
-| inputVolumeMul | Number | New volume level multiplier |
-| inputVolumeDb | Number | New volume level in dB |
+| inputVolumeMul | Number(double) | New volume level multiplier |
+| inputVolumeDb | Number(double) | New volume level in dB |
 
 ---
 
@@ -1983,7 +1983,7 @@ The audio balance value of an input has changed.
 | ---- | :---: | ----------- |
 | inputName | String | Name of the input |
 | inputUuid | String | UUID of the input |
-| inputAudioBalance | Number | New audio balance value of the input |
+| inputAudioBalance | Number(float) | New audio balance value of the input |
 
 ---
 
@@ -2001,7 +2001,7 @@ The sync offset of an input has changed.
 | ---- | :---: | ----------- |
 | inputName | String | Name of the input |
 | inputUuid | String | UUID of the input |
-| inputAudioSyncOffset | Number | New sync offset in milliseconds |
+| inputAudioSyncOffset | Number(int64) | New sync offset in milliseconds |
 
 ---
 
@@ -2092,7 +2092,7 @@ The current scene transition duration has changed.
 
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
-| transitionDuration | Number | Transition duration in milliseconds |
+| transitionDuration | Number(int32) | Transition duration in milliseconds |
 
 ---
 
@@ -2186,7 +2186,7 @@ A filter has been added to a source.
 | sourceName | String | Name of the source the filter was added to |
 | filterName | String | Name of the filter |
 | filterKind | String | The kind of the filter |
-| filterIndex | Number | Index position of the filter |
+| filterIndex | Number(int64) | Index position of the filter |
 | filterSettings | Object | The settings configured to the filter when it was created |
 | defaultFilterSettings | Object | The default settings for the filter |
 
@@ -2279,8 +2279,8 @@ A scene item has been created.
 | sceneUuid | String | UUID of the scene the item was added to |
 | sourceName | String | Name of the underlying source (input/scene) |
 | sourceUuid | String | UUID of the underlying source (input/scene) |
-| sceneItemId | Number | Numeric ID of the scene item |
-| sceneItemIndex | Number | Index position of the item |
+| sceneItemId | Number(int64) | Numeric ID of the scene item |
+| sceneItemIndex | Number(int32) | Index position of the item |
 
 ---
 
@@ -2302,7 +2302,7 @@ This event is not emitted when the scene the item is in is removed.
 | sceneUuid | String | UUID of the scene the item was removed from |
 | sourceName | String | Name of the underlying source (input/scene) |
 | sourceUuid | String | UUID of the underlying source (input/scene) |
-| sceneItemId | Number | Numeric ID of the scene item |
+| sceneItemId | Number(int64) | Numeric ID of the scene item |
 
 ---
 
@@ -2394,7 +2394,7 @@ The transform/crop of a scene item has changed.
 | ---- | :---: | ----------- |
 | sceneName | String | The name of the scene the item is in |
 | sceneUuid | String | The UUID of the scene the item is in |
-| sceneItemId | Number | Numeric ID of the scene item |
+| sceneItemId | Number(int64) | Numeric ID of the scene item |
 | sceneItemTransform | Object | New transform/crop info of the scene item |
 
 ## Outputs Events
@@ -2782,17 +2782,17 @@ Gets statistics about OBS, obs-websocket, and the current session.
 
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
-| cpuUsage | Number | Current CPU usage in percent |
-| memoryUsage | Number | Amount of memory in MB currently being used by OBS |
-| availableDiskSpace | Number | Available disk space on the device being used for recording storage |
-| activeFps | Number | Current FPS being rendered |
-| averageFrameRenderTime | Number | Average time in milliseconds that OBS is taking to render a frame |
-| renderSkippedFrames | Number | Number of frames skipped by OBS in the render thread |
-| renderTotalFrames | Number | Total number of frames outputted by the render thread |
-| outputSkippedFrames | Number | Number of frames skipped by OBS in the output thread |
-| outputTotalFrames | Number | Total number of frames outputted by the output thread |
-| webSocketSessionIncomingMessages | Number | Total number of messages received by obs-websocket from the client |
-| webSocketSessionOutgoingMessages | Number | Total number of messages sent by obs-websocket to the client |
+| cpuUsage | Number(double) | Current CPU usage in percent |
+| memoryUsage | Number(double) | Amount of memory in MB currently being used by OBS |
+| availableDiskSpace | Number(double) | Available disk space on the device being used for recording storage |
+| activeFps | Number(double) | Current FPS being rendered |
+| averageFrameRenderTime | Number(double) | Average time in milliseconds that OBS is taking to render a frame |
+| renderSkippedFrames | Number(uint32) | Number of frames skipped by OBS in the render thread |
+| renderTotalFrames | Number(uint32) | Total number of frames outputted by the render thread |
+| outputSkippedFrames | Number(uint32) | Number of frames skipped by OBS in the output thread |
+| outputTotalFrames | Number(uint32) | Total number of frames outputted by the output thread |
+| webSocketSessionIncomingMessages | Number(uint64) | Total number of messages received by obs-websocket from the client |
+| webSocketSessionOutgoingMessages | Number(uint64) | Total number of messages sent by obs-websocket to the client |
 
 ---
 
@@ -2913,8 +2913,8 @@ Sleeps for a time duration or number of frames. Only available in request batche
 
 | Name | Type  | Description | Value Restrictions | ?Default Behavior |
 | ---- | :---: | ----------- | :----------------: | ----------------- |
-| ?sleepMillis | Number | Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode) | >= 0, <= 50000 | Unknown |
-| ?sleepFrames | Number | Number of frames to sleep for (if `SERIAL_FRAME` mode) | >= 0, <= 10000 | Unknown |
+| ?sleepMillis | Number(int64) | Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode) | >= 0, <= 50000 | Unknown |
+| ?sleepFrames | Number(int64) | Number of frames to sleep for (if `SERIAL_FRAME` mode) | >= 0, <= 10000 | Unknown |
 
 ## Config Requests
 
@@ -3133,12 +3133,12 @@ Note: To get the true FPS value, divide the FPS numerator by the FPS denominator
 
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
-| fpsNumerator | Number | Numerator of the fractional FPS value |
-| fpsDenominator | Number | Denominator of the fractional FPS value |
-| baseWidth | Number | Width of the base (canvas) resolution in pixels |
-| baseHeight | Number | Height of the base (canvas) resolution in pixels |
-| outputWidth | Number | Width of the output resolution in pixels |
-| outputHeight | Number | Height of the output resolution in pixels |
+| fpsNumerator | Number(uint32) | Numerator of the fractional FPS value |
+| fpsDenominator | Number(uint32) | Denominator of the fractional FPS value |
+| baseWidth | Number(uint32) | Width of the base (canvas) resolution in pixels |
+| baseHeight | Number(uint32) | Height of the base (canvas) resolution in pixels |
+| outputWidth | Number(uint32) | Width of the output resolution in pixels |
+| outputHeight | Number(uint32) | Height of the output resolution in pixels |
 
 ---
 
@@ -3156,12 +3156,12 @@ Note: Fields must be specified in pairs. For example, you cannot set only `baseW
 
 | Name | Type  | Description | Value Restrictions | ?Default Behavior |
 | ---- | :---: | ----------- | :----------------: | ----------------- |
-| ?fpsNumerator | Number | Numerator of the fractional FPS value | >= 1 | Not changed |
-| ?fpsDenominator | Number | Denominator of the fractional FPS value | >= 1 | Not changed |
-| ?baseWidth | Number | Width of the base (canvas) resolution in pixels | >= 1, <= 4096 | Not changed |
-| ?baseHeight | Number | Height of the base (canvas) resolution in pixels | >= 1, <= 4096 | Not changed |
-| ?outputWidth | Number | Width of the output resolution in pixels | >= 1, <= 4096 | Not changed |
-| ?outputHeight | Number | Height of the output resolution in pixels | >= 1, <= 4096 | Not changed |
+| ?fpsNumerator | Number(uint64) | Numerator of the fractional FPS value | >= 1 | Not changed |
+| ?fpsDenominator | Number(uint64) | Denominator of the fractional FPS value | >= 1 | Not changed |
+| ?baseWidth | Number(uint64) | Width of the base (canvas) resolution in pixels | >= 1, <= 4096 | Not changed |
+| ?baseHeight | Number(uint64) | Height of the base (canvas) resolution in pixels | >= 1, <= 4096 | Not changed |
+| ?outputWidth | Number(uint64) | Width of the output resolution in pixels | >= 1, <= 4096 | Not changed |
+| ?outputHeight | Number(uint64) | Height of the output resolution in pixels | >= 1, <= 4096 | Not changed |
 
 ---
 
@@ -3279,9 +3279,9 @@ If `imageWidth` and `imageHeight` are not specified, the compressed image will u
 | ?sourceName | String | Name of the source to take a screenshot of | None | Unknown |
 | ?sourceUuid | String | UUID of the source to take a screenshot of | None | Unknown |
 | imageFormat | String | Image compression format to use. Use `GetVersion` to get compatible image formats | None | N/A |
-| ?imageWidth | Number | Width to scale the screenshot to | >= 8, <= 4096 | Source value is used |
-| ?imageHeight | Number | Height to scale the screenshot to | >= 8, <= 4096 | Source value is used |
-| ?imageCompressionQuality | Number | Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk) | >= -1, <= 100 | -1 |
+| ?imageWidth | Number(uint32) | Width to scale the screenshot to | >= 8, <= 4096 | Source value is used |
+| ?imageHeight | Number(uint32) | Height to scale the screenshot to | >= 8, <= 4096 | Source value is used |
+| ?imageCompressionQuality | Number(int32) | Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk) | >= -1, <= 100 | -1 |
 
 **Response Fields:**
 
@@ -3312,9 +3312,9 @@ If `imageWidth` and `imageHeight` are not specified, the compressed image will u
 | ?sourceUuid | String | UUID of the source to take a screenshot of | None | Unknown |
 | imageFormat | String | Image compression format to use. Use `GetVersion` to get compatible image formats | None | N/A |
 | imageFilePath | String | Path to save the screenshot file to. Eg. `C:\Users\user\Desktop\screenshot.png` | None | N/A |
-| ?imageWidth | Number | Width to scale the screenshot to | >= 8, <= 4096 | Source value is used |
-| ?imageHeight | Number | Height to scale the screenshot to | >= 8, <= 4096 | Source value is used |
-| ?imageCompressionQuality | Number | Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk) | >= -1, <= 100 | -1 |
+| ?imageWidth | Number(uint32) | Width to scale the screenshot to | >= 8, <= 4096 | Source value is used |
+| ?imageHeight | Number(uint32) | Height to scale the screenshot to | >= 8, <= 4096 | Source value is used |
+| ?imageCompressionQuality | Number(int32) | Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk) | >= -1, <= 100 | -1 |
 
 ## Scenes Requests
 
@@ -3515,7 +3515,7 @@ Note: A transition UUID response field is not currently able to be implemented a
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
 | transitionName | String | Name of the overridden scene transition, else `null` |
-| transitionDuration | Number | Duration of the overridden scene transition, else `null` |
+| transitionDuration | Number(int64) | Duration of the overridden scene transition, else `null` |
 
 ---
 
@@ -3534,7 +3534,7 @@ Sets the scene transition overridden for a scene.
 | ?sceneName | String | Name of the scene | None | Unknown |
 | ?sceneUuid | String | UUID of the scene | None | Unknown |
 | ?transitionName | String | Name of the scene transition to use as override. Specify `null` to remove | None | Unchanged |
-| ?transitionDuration | Number | Duration to use for any overridden transition. Specify `null` to remove | >= 50, <= 20000 | Unchanged |
+| ?transitionDuration | Number(int64) | Duration to use for any overridden transition. Specify `null` to remove | >= 50, <= 20000 | Unchanged |
 
 ## Inputs Requests
 
@@ -3627,7 +3627,7 @@ Creates a new input, adding it as a scene item to the specified scene.
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
 | inputUuid | String | UUID of the newly created input |
-| sceneItemId | Number | ID of the newly created scene item |
+| sceneItemId | Number(int64) | ID of the newly created scene item |
 
 ---
 
@@ -3818,8 +3818,8 @@ Gets the current volume setting of an input.
 
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
-| inputVolumeMul | Number | Volume setting in mul |
-| inputVolumeDb | Number | Volume setting in dB |
+| inputVolumeMul | Number(float) | Volume setting in mul |
+| inputVolumeDb | Number(float) | Volume setting in dB |
 
 ---
 
@@ -3837,8 +3837,8 @@ Sets the volume setting of an input.
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?inputName | String | Name of the input to set the volume of | None | Unknown |
 | ?inputUuid | String | UUID of the input to set the volume of | None | Unknown |
-| ?inputVolumeMul | Number | Volume setting in mul | >= 0, <= 20 | `inputVolumeDb` should be specified |
-| ?inputVolumeDb | Number | Volume setting in dB | >= -100, <= 26 | `inputVolumeMul` should be specified |
+| ?inputVolumeMul | Number(float) | Volume setting in mul | >= 0, <= 20 | `inputVolumeDb` should be specified |
+| ?inputVolumeDb | Number(float) | Volume setting in dB | >= -100, <= 26 | `inputVolumeMul` should be specified |
 
 ---
 
@@ -3861,7 +3861,7 @@ Gets the audio balance of an input.
 
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
-| inputAudioBalance | Number | Audio balance value from 0.0-1.0 |
+| inputAudioBalance | Number(float) | Audio balance value from 0.0-1.0 |
 
 ---
 
@@ -3879,7 +3879,7 @@ Sets the audio balance of an input.
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?inputName | String | Name of the input to set the audio balance of | None | Unknown |
 | ?inputUuid | String | UUID of the input to set the audio balance of | None | Unknown |
-| inputAudioBalance | Number | New audio balance value | >= 0.0, <= 1.0 | N/A |
+| inputAudioBalance | Number(float) | New audio balance value | >= 0.0, <= 1.0 | N/A |
 
 ---
 
@@ -3904,7 +3904,7 @@ Note: The audio sync offset can be negative too!
 
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
-| inputAudioSyncOffset | Number | Audio sync offset in milliseconds |
+| inputAudioSyncOffset | Number(int64) | Audio sync offset in milliseconds |
 
 ---
 
@@ -3922,7 +3922,7 @@ Sets the audio sync offset of an input.
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?inputName | String | Name of the input to set the audio sync offset of | None | Unknown |
 | ?inputUuid | String | UUID of the input to set the audio sync offset of | None | Unknown |
-| inputAudioSyncOffset | Number | New audio sync offset in milliseconds | >= -950, <= 20000 | N/A |
+| inputAudioSyncOffset | Number(int64) | New audio sync offset in milliseconds | >= -950, <= 20000 | N/A |
 
 ---
 
@@ -4153,7 +4153,7 @@ Sets the duration of the current scene transition, if it is not fixed.
 
 | Name | Type  | Description | Value Restrictions | ?Default Behavior |
 | ---- | :---: | ----------- | :----------------: | ----------------- |
-| transitionDuration | Number | Duration in milliseconds | >= 50, <= 20000 | N/A |
+| transitionDuration | Number(int32) | Duration in milliseconds | >= 50, <= 20000 | N/A |
 
 ---
 
@@ -4188,7 +4188,7 @@ Note: `transitionCursor` will return 1.0 when the transition is inactive.
 
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
-| transitionCursor | Number | Cursor position, between 0.0 and 1.0 |
+| transitionCursor | Number(float) | Cursor position, between 0.0 and 1.0 |
 
 ---
 
@@ -4383,7 +4383,7 @@ Sets the index position of a filter on a source.
 | ?sourceName | String | Name of the source the filter is on | None | Unknown |
 | ?sourceUuid | String | UUID of the source the filter is on | None | Unknown |
 | filterName | String | Name of the filter | None | N/A |
-| filterIndex | Number | New index position of the filter | >= 0 | N/A |
+| filterIndex | Number(int32) | New index position of the filter | >= 0 | N/A |
 
 ---
 
@@ -4495,13 +4495,13 @@ Scenes and Groups
 | ?sceneName | String | Name of the scene or group to search in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene or group to search in | None | Unknown |
 | sourceName | String | Name of the source to find | None | N/A |
-| ?searchOffset | Number | Number of matches to skip during search. >= 0 means first forward. -1 means last (top) item | >= -1 | 0 |
+| ?searchOffset | Number(int32) | Number of matches to skip during search. >= 0 means first forward. -1 means last (top) item | >= -1 | 0 |
 
 **Response Fields:**
 
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
-| sceneItemId | Number | Numeric ID of the scene item |
+| sceneItemId | Number(int64) | Numeric ID of the scene item |
 
 ---
 
@@ -4519,7 +4519,7 @@ Gets the source associated with a scene item.
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 
 **Response Fields:**
 
@@ -4554,7 +4554,7 @@ Scenes only
 
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
-| sceneItemId | Number | Numeric ID of the scene item |
+| sceneItemId | Number(int64) | Numeric ID of the scene item |
 
 ---
 
@@ -4574,7 +4574,7 @@ Scenes only
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 
 ---
 
@@ -4594,7 +4594,7 @@ Scenes only
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 | ?destinationSceneName | String | Name of the scene to create the duplicated item in | None | From scene is assumed |
 | ?destinationSceneUuid | String | UUID of the scene to create the duplicated item in | None | From scene is assumed |
 
@@ -4602,7 +4602,7 @@ Scenes only
 
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
-| sceneItemId | Number | Numeric ID of the duplicated scene item |
+| sceneItemId | Number(int64) | Numeric ID of the duplicated scene item |
 
 ---
 
@@ -4622,7 +4622,7 @@ Scenes and Groups
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 
 **Response Fields:**
 
@@ -4646,7 +4646,7 @@ Sets the transform and crop info of a scene item.
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 | sceneItemTransform | Object | Object containing scene item transform info to update | None | N/A |
 
 ---
@@ -4667,7 +4667,7 @@ Scenes and Groups
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 
 **Response Fields:**
 
@@ -4693,7 +4693,7 @@ Scenes and Groups
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 | sceneItemEnabled | Boolean | New enable state of the scene item | None | N/A |
 
 ---
@@ -4714,7 +4714,7 @@ Scenes and Groups
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 
 **Response Fields:**
 
@@ -4740,7 +4740,7 @@ Scenes and Group
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 | sceneItemLocked | Boolean | New lock state of the scene item | None | N/A |
 
 ---
@@ -4763,13 +4763,13 @@ Scenes and Groups
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 
 **Response Fields:**
 
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
-| sceneItemIndex | Number | Index position of the scene item |
+| sceneItemIndex | Number(int32) | Index position of the scene item |
 
 ---
 
@@ -4789,8 +4789,8 @@ Scenes and Groups
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
-| sceneItemIndex | Number | New index position of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemIndex | Number(int32) | New index position of the scene item | >= 0 | N/A |
 
 ---
 
@@ -4820,7 +4820,7 @@ Scenes and Groups
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 
 **Response Fields:**
 
@@ -4846,7 +4846,7 @@ Scenes and Groups
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sceneName | String | Name of the scene the item is in | None | Unknown |
 | ?sceneUuid | String | UUID of the scene the item is in | None | Unknown |
-| sceneItemId | Number | Numeric ID of the scene item | >= 0 | N/A |
+| sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0 | N/A |
 | sceneItemBlendMode | String | New blend mode | None | N/A |
 
 ## Outputs Requests
@@ -5345,8 +5345,8 @@ Media States:
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
 | mediaState | String | State of the media input |
-| mediaDuration | Number | Total duration of the playing media in milliseconds. `null` if not playing |
-| mediaCursor | Number | Position of the cursor in milliseconds. `null` if not playing |
+| mediaDuration | Number(int64) | Total duration of the playing media in milliseconds. `null` if not playing |
+| mediaCursor | Number(int64) | Position of the cursor in milliseconds. `null` if not playing |
 
 ---
 
@@ -5366,7 +5366,7 @@ This request does not perform bounds checking of the cursor position.
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?inputName | String | Name of the media input | None | Unknown |
 | ?inputUuid | String | UUID of the media input | None | Unknown |
-| mediaCursor | Number | New cursor position to set | >= 0 | N/A |
+| mediaCursor | Number(int64) | New cursor position to set | >= 0 | N/A |
 
 ---
 
@@ -5386,7 +5386,7 @@ This request does not perform bounds checking of the cursor position.
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?inputName | String | Name of the media input | None | Unknown |
 | ?inputUuid | String | UUID of the media input | None | Unknown |
-| mediaCursorOffset | Number | Value to offset the current cursor position by | None | N/A |
+| mediaCursorOffset | Number(int64) | Value to offset the current cursor position by | None | N/A |
 
 ---
 
@@ -5528,7 +5528,7 @@ Note: This request serves to provide feature parity with 4.x. It is very likely 
 | Name | Type  | Description | Value Restrictions | ?Default Behavior |
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | videoMixType | String | Type of mix to open | None | N/A |
-| ?monitorIndex | Number | Monitor index, use `GetMonitorList` to obtain index | None | -1: Opens projector in windowed mode |
+| ?monitorIndex | Number(int32) | Monitor index, use `GetMonitorList` to obtain index | None | -1: Opens projector in windowed mode |
 | ?projectorGeometry | String | Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex` | None | N/A |
 
 ---
@@ -5549,5 +5549,5 @@ Note: This request serves to provide feature parity with 4.x. It is very likely 
 | ---- | :---: | ----------- | :----------------: | ----------------- |
 | ?sourceName | String | Name of the source to open a projector for | None | Unknown |
 | ?sourceUuid | String | UUID of the source to open a projector for | None | Unknown |
-| ?monitorIndex | Number | Monitor index, use `GetMonitorList` to obtain index | None | -1: Opens projector in windowed mode |
+| ?monitorIndex | Number(int32) | Monitor index, use `GetMonitorList` to obtain index | None | -1: Opens projector in windowed mode |
 | ?projectorGeometry | String | Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex` | None | N/A |

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -2338,7 +2338,7 @@ A scene item's enable state has changed.
 | ---- | :---: | ----------- |
 | sceneName | String | Name of the scene the item is in |
 | sceneUuid | String | UUID of the scene the item is in |
-| sceneItemId | Number | Numeric ID of the scene item |
+| sceneItemId | Number(int64) | Numeric ID of the scene item |
 | sceneItemEnabled | Boolean | Whether the scene item is enabled (visible) |
 
 ---
@@ -2357,7 +2357,7 @@ A scene item's lock state has changed.
 | ---- | :---: | ----------- |
 | sceneName | String | Name of the scene the item is in |
 | sceneUuid | String | UUID of the scene the item is in |
-| sceneItemId | Number | Numeric ID of the scene item |
+| sceneItemId | Number(int64) | Numeric ID of the scene item |
 | sceneItemLocked | Boolean | Whether the scene item is locked |
 
 ---
@@ -2376,7 +2376,7 @@ A scene item has been selected in the Ui.
 | ---- | :---: | ----------- |
 | sceneName | String | Name of the scene the item is in |
 | sceneUuid | String | UUID of the scene the item is in |
-| sceneItemId | Number | Numeric ID of the scene item |
+| sceneItemId | Number(int64) | Numeric ID of the scene item |
 
 ---
 
@@ -2762,7 +2762,7 @@ Gets data about the current plugin and RPC version.
 | ---- | :---: | ----------- |
 | obsVersion | String | Current OBS Studio version |
 | obsWebSocketVersion | String | Current obs-websocket version |
-| rpcVersion | Number | Current latest obs-websocket RPC version |
+| rpcVersion | Number(int32) | Current latest obs-websocket RPC version |
 | availableRequests | Array&lt;String&gt; | Array of available RPC requests for the currently negotiated RPC version |
 | supportedImageFormats | Array&lt;String&gt; | Image formats available in `GetSourceScreenshot` and `SaveSourceScreenshot` requests. |
 | platform | String | Name of the platform. Usually `windows`, `macos`, or `ubuntu` (linux flavor). Not guaranteed to be any of those |
@@ -4117,7 +4117,7 @@ Gets information about the current scene transition.
 | transitionUuid | String | UUID of the transition |
 | transitionKind | String | Kind of the transition |
 | transitionFixed | Boolean | Whether the transition uses a fixed (unconfigurable) duration |
-| transitionDuration | Number | Configured transition duration in milliseconds. `null` if transition is fixed |
+| transitionDuration | Number(int32) | Configured transition duration in milliseconds. `null` if transition is fixed |
 | transitionConfigurable | Boolean | Whether the transition supports being configured |
 | transitionSettings | Object | Object of settings for the transition. `null` if transition is not configurable |
 
@@ -4216,7 +4216,7 @@ Sets the position of the TBar.
 
 | Name | Type  | Description | Value Restrictions | ?Default Behavior |
 | ---- | :---: | ----------- | :----------------: | ----------------- |
-| position | Number | New position | >= 0.0, <= 1.0 | N/A |
+| position | Number(float) | New position | >= 0.0, <= 1.0 | N/A |
 | ?release | Boolean | Whether to release the TBar. Only set `false` if you know that you will be sending another position update | None | `true` |
 
 ## Filters Requests
@@ -4362,7 +4362,7 @@ Gets the info for a specific source filter.
 | Name | Type  | Description |
 | ---- | :---: | ----------- |
 | filterEnabled | Boolean | Whether the filter is enabled |
-| filterIndex | Number | Index of the filter in the list, beginning at 0 |
+| filterIndex | Number(int64) | Index of the filter in the list, beginning at 0 |
 | filterKind | String | The kind of filter |
 | filterSettings | Object | Settings object associated with the filter |
 
@@ -5018,10 +5018,10 @@ Gets the status of an output.
 | outputActive | Boolean | Whether the output is active |
 | outputReconnecting | Boolean | Whether the output is reconnecting |
 | outputTimecode | String | Current formatted timecode string for the output |
-| outputDuration | Number | Current duration in milliseconds for the output |
-| outputCongestion | Number | Congestion of the output |
-| outputBytes | Number | Number of bytes sent by the output |
-| outputSkippedFrames | Number | Number of frames skipped by the output's process |
+| outputDuration | Number(uint64) | Current duration in milliseconds for the output |
+| outputCongestion | Number(float) | Congestion of the output |
+| outputBytes | Number(uint64) | Number of bytes sent by the output |
+| outputSkippedFrames | Number(int32) | Number of frames skipped by the output's process |
 | outputTotalFrames | Number | Total number of frames delivered by the output's process |
 
 ---
@@ -5134,11 +5134,11 @@ Gets the status of the stream output.
 | outputActive | Boolean | Whether the output is active |
 | outputReconnecting | Boolean | Whether the output is currently reconnecting |
 | outputTimecode | String | Current formatted timecode string for the output |
-| outputDuration | Number | Current duration in milliseconds for the output |
-| outputCongestion | Number | Congestion of the output |
-| outputBytes | Number | Number of bytes sent by the output |
-| outputSkippedFrames | Number | Number of frames skipped by the output's process |
-| outputTotalFrames | Number | Total number of frames delivered by the output's process |
+| outputDuration | Number(uint64) | Current duration in milliseconds for the output |
+| outputCongestion | Number(float) | Congestion of the output |
+| outputBytes | Number(uint64) | Number of bytes sent by the output |
+| outputSkippedFrames | Number(int32) | Number of frames skipped by the output's process |
+| outputTotalFrames | Number(int32) | Total number of frames delivered by the output's process |
 
 ---
 
@@ -5209,8 +5209,8 @@ Gets the status of the record output.
 | outputActive | Boolean | Whether the output is active |
 | outputPaused | Boolean | Whether the output is paused |
 | outputTimecode | String | Current formatted timecode string for the output |
-| outputDuration | Number | Current duration in milliseconds for the output |
-| outputBytes | Number | Number of bytes sent by the output |
+| outputDuration | Number(uint64) | Current duration in milliseconds for the output |
+| outputBytes | Number(uint64) | Number of bytes sent by the output |
 
 ---
 

--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -5022,7 +5022,7 @@ Gets the status of an output.
 | outputCongestion | Number(float) | Congestion of the output |
 | outputBytes | Number(uint64) | Number of bytes sent by the output |
 | outputSkippedFrames | Number(int32) | Number of frames skipped by the output's process |
-| outputTotalFrames | Number | Total number of frames delivered by the output's process |
+| outputTotalFrames | Number(int32) | Total number of frames delivered by the output's process |
 
 ---
 

--- a/src/eventhandler/EventHandler_Filters.cpp
+++ b/src/eventhandler/EventHandler_Filters.cpp
@@ -80,12 +80,12 @@ void EventHandler::HandleSourceFilterListReindexed(void *param, calldata_t *data
 /**
  * A filter has been added to a source.
  *
- * @dataField sourceName            | String | Name of the source the filter was added to
- * @dataField filterName            | String | Name of the filter
- * @dataField filterKind            | String | The kind of the filter
- * @dataField filterIndex           | Number | Index position of the filter
- * @dataField filterSettings        | Object | The settings configured to the filter when it was created
- * @dataField defaultFilterSettings | Object | The default settings for the filter
+ * @dataField sourceName            | String        | Name of the source the filter was added to
+ * @dataField filterName            | String        | Name of the filter
+ * @dataField filterKind            | String        | The kind of the filter
+ * @dataField filterIndex           | Number(int64) | Index position of the filter
+ * @dataField filterSettings        | Object        | The settings configured to the filter when it was created
+ * @dataField defaultFilterSettings | Object        | The default settings for the filter
  *
  * @eventType SourceFilterCreated
  * @eventSubscription Filters

--- a/src/eventhandler/EventHandler_Inputs.cpp
+++ b/src/eventhandler/EventHandler_Inputs.cpp
@@ -239,10 +239,10 @@ void EventHandler::HandleInputMuteStateChanged(void *param, calldata_t *data)
 /**
  * An input's volume level has changed.
  *
- * @dataField inputName      | String | Name of the input
- * @dataField inputUuid      | String | UUID of the input
- * @dataField inputVolumeMul | Number | New volume level multiplier
- * @dataField inputVolumeDb  | Number | New volume level in dB
+ * @dataField inputName      | String         | Name of the input
+ * @dataField inputUuid      | String         | UUID of the input
+ * @dataField inputVolumeMul | Number(double) | New volume level multiplier
+ * @dataField inputVolumeDb  | Number(double) | New volume level in dB
  *
  * @eventType InputVolumeChanged
  * @eventSubscription Inputs
@@ -281,9 +281,9 @@ void EventHandler::HandleInputVolumeChanged(void *param, calldata_t *data)
 /**
  * The audio balance value of an input has changed.
  *
- * @dataField inputName         | String | Name of the input
- * @dataField inputUuid         | String | UUID of the input
- * @dataField inputAudioBalance | Number | New audio balance value of the input
+ * @dataField inputName         | String        | Name of the input
+ * @dataField inputUuid         | String        | UUID of the input
+ * @dataField inputAudioBalance | Number(float) | New audio balance value of the input
  *
  * @eventType InputAudioBalanceChanged
  * @eventSubscription Inputs
@@ -316,9 +316,9 @@ void EventHandler::HandleInputAudioBalanceChanged(void *param, calldata_t *data)
 /**
  * The sync offset of an input has changed.
  *
- * @dataField inputName            | String | Name of the input
- * @dataField inputUuid            | String | UUID of the input
- * @dataField inputAudioSyncOffset | Number | New sync offset in milliseconds
+ * @dataField inputName            | String        | Name of the input
+ * @dataField inputUuid            | String        | UUID of the input
+ * @dataField inputAudioSyncOffset | Number(int64) | New sync offset in milliseconds
  *
  * @eventType InputAudioSyncOffsetChanged
  * @eventSubscription Inputs

--- a/src/eventhandler/EventHandler_SceneItems.cpp
+++ b/src/eventhandler/EventHandler_SceneItems.cpp
@@ -22,12 +22,12 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 /**
  * A scene item has been created.
  *
- * @dataField sceneName      | String | Name of the scene the item was added to
- * @dataField sceneUuid      | String | UUID of the scene the item was added to
- * @dataField sourceName     | String | Name of the underlying source (input/scene)
- * @dataField sourceUuid     | String | UUID of the underlying source (input/scene)
- * @dataField sceneItemId    | Number | Numeric ID of the scene item
- * @dataField sceneItemIndex | Number | Index position of the item
+ * @dataField sceneName      | String        | Name of the scene the item was added to
+ * @dataField sceneUuid      | String        | UUID of the scene the item was added to
+ * @dataField sourceName     | String        | Name of the underlying source (input/scene)
+ * @dataField sourceUuid     | String        | UUID of the underlying source (input/scene)
+ * @dataField sceneItemId    | Number(int64) | Numeric ID of the scene item
+ * @dataField sceneItemIndex | Number(int32) | Index position of the item
  *
  * @eventType SceneItemCreated
  * @eventSubscription SceneItems
@@ -64,11 +64,11 @@ void EventHandler::HandleSceneItemCreated(void *param, calldata_t *data)
  *
  * This event is not emitted when the scene the item is in is removed.
  *
- * @dataField sceneName   | String | Name of the scene the item was removed from
- * @dataField sceneUuid   | String | UUID of the scene the item was removed from
- * @dataField sourceName  | String | Name of the underlying source (input/scene)
- * @dataField sourceUuid  | String | UUID of the underlying source (input/scene)
- * @dataField sceneItemId | Number | Numeric ID of the scene item
+ * @dataField sceneName   | String        | Name of the scene the item was removed from
+ * @dataField sceneUuid   | String        | UUID of the scene the item was removed from
+ * @dataField sourceName  | String        | Name of the underlying source (input/scene)
+ * @dataField sourceUuid  | String        | UUID of the underlying source (input/scene)
+ * @dataField sceneItemId | Number(int64) | Numeric ID of the scene item
  *
  * @eventType SceneItemRemoved
  * @eventSubscription SceneItems
@@ -242,10 +242,10 @@ void EventHandler::HandleSceneItemSelected(void *param, calldata_t *data)
 /**
  * The transform/crop of a scene item has changed.
  *
- * @dataField sceneName          | String | The name of the scene the item is in
- * @dataField sceneUuid          | String | The UUID of the scene the item is in
- * @dataField sceneItemId        | Number | Numeric ID of the scene item
- * @dataField sceneItemTransform | Object | New transform/crop info of the scene item
+ * @dataField sceneName          | String        | The name of the scene the item is in
+ * @dataField sceneUuid          | String        | The UUID of the scene the item is in
+ * @dataField sceneItemId        | Number(int64) | Numeric ID of the scene item
+ * @dataField sceneItemTransform | Object        | New transform/crop info of the scene item
  *
  * @eventType SceneItemTransformChanged
  * @eventSubscription SceneItemTransformChanged

--- a/src/eventhandler/EventHandler_SceneItems.cpp
+++ b/src/eventhandler/EventHandler_SceneItems.cpp
@@ -132,10 +132,10 @@ void EventHandler::HandleSceneItemListReindexed(void *param, calldata_t *data)
 /**
  * A scene item's enable state has changed.
  *
- * @dataField sceneName        | String  | Name of the scene the item is in
- * @dataField sceneUuid        | String  | UUID of the scene the item is in
- * @dataField sceneItemId      | Number  | Numeric ID of the scene item
- * @dataField sceneItemEnabled | Boolean | Whether the scene item is enabled (visible)
+ * @dataField sceneName        | String        | Name of the scene the item is in
+ * @dataField sceneUuid        | String        | UUID of the scene the item is in
+ * @dataField sceneItemId      | Number(int64) | Numeric ID of the scene item
+ * @dataField sceneItemEnabled | Boolean       | Whether the scene item is enabled (visible)
  *
  * @eventType SceneItemEnableStateChanged
  * @eventSubscription SceneItems
@@ -170,10 +170,10 @@ void EventHandler::HandleSceneItemEnableStateChanged(void *param, calldata_t *da
 /**
  * A scene item's lock state has changed.
  *
- * @dataField sceneName       | String  | Name of the scene the item is in
- * @dataField sceneUuid       | String  | UUID of the scene the item is in
- * @dataField sceneItemId     | Number  | Numeric ID of the scene item
- * @dataField sceneItemLocked | Boolean | Whether the scene item is locked
+ * @dataField sceneName       | String        | Name of the scene the item is in
+ * @dataField sceneUuid       | String        | UUID of the scene the item is in
+ * @dataField sceneItemId     | Number(int64) | Numeric ID of the scene item
+ * @dataField sceneItemLocked | Boolean       | Whether the scene item is locked
  *
  * @eventType SceneItemLockStateChanged
  * @eventSubscription SceneItems
@@ -208,9 +208,9 @@ void EventHandler::HandleSceneItemLockStateChanged(void *param, calldata_t *data
 /**
  * A scene item has been selected in the Ui.
  *
- * @dataField sceneName        | String  | Name of the scene the item is in
- * @dataField sceneUuid        | String  | UUID of the scene the item is in
- * @dataField sceneItemId      | Number  | Numeric ID of the scene item
+ * @dataField sceneName        | String        | Name of the scene the item is in
+ * @dataField sceneUuid        | String        | UUID of the scene the item is in
+ * @dataField sceneItemId      | Number(int64) | Numeric ID of the scene item
  *
  * @eventType SceneItemSelected
  * @eventSubscription SceneItems

--- a/src/eventhandler/EventHandler_Transitions.cpp
+++ b/src/eventhandler/EventHandler_Transitions.cpp
@@ -46,7 +46,7 @@ void EventHandler::HandleCurrentSceneTransitionChanged()
 /**
  * The current scene transition duration has changed.
  *
- * @dataField transitionDuration | Number | Transition duration in milliseconds
+ * @dataField transitionDuration | Number(int32) | Transition duration in milliseconds
  *
  * @eventType CurrentSceneTransitionDurationChanged
  * @eventSubscription Transitions

--- a/src/requesthandler/RequestHandler_Config.cpp
+++ b/src/requesthandler/RequestHandler_Config.cpp
@@ -428,12 +428,12 @@ RequestResult RequestHandler::SetProfileParameter(const Request &request)
  *
  * Note: To get the true FPS value, divide the FPS numerator by the FPS denominator. Example: `60000/1001`
  *
- * @responseField fpsNumerator   | Number | Numerator of the fractional FPS value
- * @responseField fpsDenominator | Number | Denominator of the fractional FPS value
- * @responseField baseWidth      | Number | Width of the base (canvas) resolution in pixels
- * @responseField baseHeight     | Number | Height of the base (canvas) resolution in pixels
- * @responseField outputWidth    | Number | Width of the output resolution in pixels
- * @responseField outputHeight   | Number | Height of the output resolution in pixels
+ * @responseField fpsNumerator   | Number(uint32) | Numerator of the fractional FPS value
+ * @responseField fpsDenominator | Number(uint32) | Denominator of the fractional FPS value
+ * @responseField baseWidth      | Number(uint32) | Width of the base (canvas) resolution in pixels
+ * @responseField baseHeight     | Number(uint32) | Height of the base (canvas) resolution in pixels
+ * @responseField outputWidth    | Number(uint32) | Width of the output resolution in pixels
+ * @responseField outputHeight   | Number(uint32) | Height of the output resolution in pixels
  *
  * @requestType GetVideoSettings
  * @complexity 2
@@ -464,12 +464,12 @@ RequestResult RequestHandler::GetVideoSettings(const Request &)
  *
  * Note: Fields must be specified in pairs. For example, you cannot set only `baseWidth` without needing to specify `baseHeight`.
  *
- * @requestField ?fpsNumerator   | Number | Numerator of the fractional FPS value            | >= 1          | Not changed
- * @requestField ?fpsDenominator | Number | Denominator of the fractional FPS value          | >= 1          | Not changed
- * @requestField ?baseWidth      | Number | Width of the base (canvas) resolution in pixels  | >= 1, <= 4096 | Not changed
- * @requestField ?baseHeight     | Number | Height of the base (canvas) resolution in pixels | >= 1, <= 4096 | Not changed
- * @requestField ?outputWidth    | Number | Width of the output resolution in pixels         | >= 1, <= 4096 | Not changed
- * @requestField ?outputHeight   | Number | Height of the output resolution in pixels        | >= 1, <= 4096 | Not changed
+ * @requestField ?fpsNumerator   | Number(uint64) | Numerator of the fractional FPS value            | >= 1          | Not changed
+ * @requestField ?fpsDenominator | Number(uint64) | Denominator of the fractional FPS value          | >= 1          | Not changed
+ * @requestField ?baseWidth      | Number(uint64) | Width of the base (canvas) resolution in pixels  | >= 1, <= 4096 | Not changed
+ * @requestField ?baseHeight     | Number(uint64) | Height of the base (canvas) resolution in pixels | >= 1, <= 4096 | Not changed
+ * @requestField ?outputWidth    | Number(uint64) | Width of the output resolution in pixels         | >= 1, <= 4096 | Not changed
+ * @requestField ?outputHeight   | Number(uint64) | Height of the output resolution in pixels        | >= 1, <= 4096 | Not changed
  *
  * @requestType SetVideoSettings
  * @complexity 2

--- a/src/requesthandler/RequestHandler_Filters.cpp
+++ b/src/requesthandler/RequestHandler_Filters.cpp
@@ -262,10 +262,10 @@ RequestResult RequestHandler::GetSourceFilter(const Request &request)
 /**
  * Sets the index position of a filter on a source.
  *
- * @requestField ?sourceName | String | Name of the source the filter is on
- * @requestField ?sourceUuid | String | UUID of the source the filter is on
- * @requestField filterName  | String | Name of the filter
- * @requestField filterIndex | Number | New index position of the filter | >= 0
+ * @requestField ?sourceName | String        | Name of the source the filter is on
+ * @requestField ?sourceUuid | String        | UUID of the source the filter is on
+ * @requestField filterName  | String        | Name of the filter
+ * @requestField filterIndex | Number(int32) | New index position of the filter | >= 0
  *
  * @requestType SetSourceFilterIndex
  * @complexity 3

--- a/src/requesthandler/RequestHandler_Filters.cpp
+++ b/src/requesthandler/RequestHandler_Filters.cpp
@@ -226,10 +226,10 @@ RequestResult RequestHandler::SetSourceFilterName(const Request &request)
  * @requestField ?sourceUuid | String | UUID of the source
  * @requestField filterName  | String | Name of the filter
  *
- * @responseField filterEnabled  | Boolean | Whether the filter is enabled
- * @responseField filterIndex    | Number  | Index of the filter in the list, beginning at 0
- * @responseField filterKind     | String  | The kind of filter
- * @responseField filterSettings | Object  | Settings object associated with the filter
+ * @responseField filterEnabled  | Boolean       | Whether the filter is enabled
+ * @responseField filterIndex    | Number(int64) | Index of the filter in the list, beginning at 0
+ * @responseField filterKind     | String        | The kind of filter
+ * @responseField filterSettings | Object        | Settings object associated with the filter
  *
  * @requestType GetSourceFilter
  * @complexity 2

--- a/src/requesthandler/RequestHandler_General.cpp
+++ b/src/requesthandler/RequestHandler_General.cpp
@@ -68,17 +68,17 @@ RequestResult RequestHandler::GetVersion(const Request &)
 /**
  * Gets statistics about OBS, obs-websocket, and the current session.
  *
- * @responseField cpuUsage                         | Number | Current CPU usage in percent
- * @responseField memoryUsage                      | Number | Amount of memory in MB currently being used by OBS
- * @responseField availableDiskSpace               | Number | Available disk space on the device being used for recording storage
- * @responseField activeFps                        | Number | Current FPS being rendered
- * @responseField averageFrameRenderTime           | Number | Average time in milliseconds that OBS is taking to render a frame
- * @responseField renderSkippedFrames              | Number | Number of frames skipped by OBS in the render thread
- * @responseField renderTotalFrames                | Number | Total number of frames outputted by the render thread
- * @responseField outputSkippedFrames              | Number | Number of frames skipped by OBS in the output thread
- * @responseField outputTotalFrames                | Number | Total number of frames outputted by the output thread
- * @responseField webSocketSessionIncomingMessages | Number | Total number of messages received by obs-websocket from the client
- * @responseField webSocketSessionOutgoingMessages | Number | Total number of messages sent by obs-websocket to the client
+ * @responseField cpuUsage                         | Number(double) | Current CPU usage in percent
+ * @responseField memoryUsage                      | Number(double) | Amount of memory in MB currently being used by OBS
+ * @responseField availableDiskSpace               | Number(double) | Available disk space on the device being used for recording storage
+ * @responseField activeFps                        | Number(double) | Current FPS being rendered
+ * @responseField averageFrameRenderTime           | Number(double) | Average time in milliseconds that OBS is taking to render a frame
+ * @responseField renderSkippedFrames              | Number(uint32) | Number of frames skipped by OBS in the render thread
+ * @responseField renderTotalFrames                | Number(uint32) | Total number of frames outputted by the render thread
+ * @responseField outputSkippedFrames              | Number(uint32) | Number of frames skipped by OBS in the output thread
+ * @responseField outputTotalFrames                | Number(uint32) | Total number of frames outputted by the output thread
+ * @responseField webSocketSessionIncomingMessages | Number(uint64) | Total number of messages received by obs-websocket from the client
+ * @responseField webSocketSessionOutgoingMessages | Number(uint64) | Total number of messages sent by obs-websocket to the client
  *
  * @requestType GetStats
  * @complexity 2
@@ -341,8 +341,8 @@ RequestResult RequestHandler::TriggerHotkeyByKeySequence(const Request &request)
 /**
  * Sleeps for a time duration or number of frames. Only available in request batches with types `SERIAL_REALTIME` or `SERIAL_FRAME`.
  *
- * @requestField ?sleepMillis | Number | Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode) | >= 0, <= 50000
- * @requestField ?sleepFrames | Number | Number of frames to sleep for (if `SERIAL_FRAME` mode) | >= 0, <= 10000
+ * @requestField ?sleepMillis | Number(int64) | Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode) | >= 0, <= 50000
+ * @requestField ?sleepFrames | Number(int64) | Number of frames to sleep for (if `SERIAL_FRAME` mode) | >= 0, <= 10000
  *
  * @requestType Sleep
  * @complexity 2

--- a/src/requesthandler/RequestHandler_General.cpp
+++ b/src/requesthandler/RequestHandler_General.cpp
@@ -31,7 +31,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
  *
  * @responseField obsVersion            | String        | Current OBS Studio version
  * @responseField obsWebSocketVersion   | String        | Current obs-websocket version
- * @responseField rpcVersion            | Number        | Current latest obs-websocket RPC version
+ * @responseField rpcVersion            | Number(int32) | Current latest obs-websocket RPC version
  * @responseField availableRequests     | Array<String> | Array of available RPC requests for the currently negotiated RPC version
  * @responseField supportedImageFormats | Array<String> | Image formats available in `GetSourceScreenshot` and `SaveSourceScreenshot` requests.
  * @responseField platform              | String        | Name of the platform. Usually `windows`, `macos`, or `ubuntu` (linux flavor). Not guaranteed to be any of those

--- a/src/requesthandler/RequestHandler_Inputs.cpp
+++ b/src/requesthandler/RequestHandler_Inputs.cpp
@@ -130,8 +130,8 @@ RequestResult RequestHandler::GetSpecialInputs(const Request &)
  * @requestField ?inputSettings    | Object | Settings object to initialize the input with                  | Default settings used
  * @requestField ?sceneItemEnabled | Boolean | Whether to set the created scene item to enabled or disabled | True
  *
- * @responseField inputUuid   | String | UUID of the newly created input
- * @responseField sceneItemId | Number | ID of the newly created scene item
+ * @responseField inputUuid   | String        | UUID of the newly created input
+ * @responseField sceneItemId | Number(int64) | ID of the newly created scene item
  *
  * @requestType CreateInput
  * @complexity 3
@@ -478,8 +478,8 @@ RequestResult RequestHandler::ToggleInputMute(const Request &request)
  * @requestField ?inputName | String | Name of the input to get the volume of
  * @requestField ?inputUuid | String | UUID of the input to get the volume of
  *
- * @responseField inputVolumeMul | Number | Volume setting in mul
- * @responseField inputVolumeDb  | Number | Volume setting in dB
+ * @responseField inputVolumeMul | Number(float) | Volume setting in mul
+ * @responseField inputVolumeDb  | Number(float) | Volume setting in dB
  *
  * @requestType GetInputVolume
  * @complexity 3
@@ -513,10 +513,10 @@ RequestResult RequestHandler::GetInputVolume(const Request &request)
 /**
  * Sets the volume setting of an input.
  *
- * @requestField ?inputName      | String | Name of the input to set the volume of
- * @requestField ?inputUuid      | String | UUID of the input to set the volume of
- * @requestField ?inputVolumeMul | Number | Volume setting in mul | >= 0, <= 20     | `inputVolumeDb` should be specified
- * @requestField ?inputVolumeDb  | Number | Volume setting in dB  | >= -100, <= 26 | `inputVolumeMul` should be specified
+ * @requestField ?inputName      | String        | Name of the input to set the volume of
+ * @requestField ?inputUuid      | String        | UUID of the input to set the volume of
+ * @requestField ?inputVolumeMul | Number(float) | Volume setting in mul | >= 0, <= 20     | `inputVolumeDb` should be specified
+ * @requestField ?inputVolumeDb  | Number(float) | Volume setting in dB  | >= -100, <= 26 | `inputVolumeMul` should be specified
  *
  * @requestType SetInputVolume
  * @complexity 3
@@ -567,7 +567,7 @@ RequestResult RequestHandler::SetInputVolume(const Request &request)
  * @requestField ?inputName | String | Name of the input to get the audio balance of
  * @requestField ?inputUuid | String | UUID of the input to get the audio balance of
  *
- * @responseField inputAudioBalance | Number | Audio balance value from 0.0-1.0
+ * @responseField inputAudioBalance | Number(float) | Audio balance value from 0.0-1.0
  *
  * @requestType GetInputAudioBalance
  * @complexity 2
@@ -596,9 +596,9 @@ RequestResult RequestHandler::GetInputAudioBalance(const Request &request)
 /**
  * Sets the audio balance of an input.
  *
- * @requestField ?inputName        | String | Name of the input to set the audio balance of
- * @requestField ?inputUuid        | String | UUID of the input to set the audio balance of
- * @requestField inputAudioBalance | Number | New audio balance value | >= 0.0, <= 1.0
+ * @requestField ?inputName        | String        | Name of the input to set the audio balance of
+ * @requestField ?inputUuid        | String        | UUID of the input to set the audio balance of
+ * @requestField inputAudioBalance | Number(float) | New audio balance value | >= 0.0, <= 1.0
  *
  * @requestType SetInputAudioBalance
  * @complexity 2
@@ -632,7 +632,7 @@ RequestResult RequestHandler::SetInputAudioBalance(const Request &request)
  * @requestField ?inputName | String | Name of the input to get the audio sync offset of
  * @requestField ?inputUuid | String | UUID of the input to get the audio sync offset of
  *
- * @responseField inputAudioSyncOffset | Number | Audio sync offset in milliseconds
+ * @responseField inputAudioSyncOffset | Number(int64) | Audio sync offset in milliseconds
  *
  * @requestType GetInputAudioSyncOffset
  * @complexity 3
@@ -662,9 +662,9 @@ RequestResult RequestHandler::GetInputAudioSyncOffset(const Request &request)
 /**
  * Sets the audio sync offset of an input.
  *
- * @requestField ?inputName           | String | Name of the input to set the audio sync offset of
- * @requestField ?inputUuid           | String | UUID of the input to set the audio sync offset of
- * @requestField inputAudioSyncOffset | Number | New audio sync offset in milliseconds | >= -950, <= 20000
+ * @requestField ?inputName           | String        | Name of the input to set the audio sync offset of
+ * @requestField ?inputUuid           | String        | UUID of the input to set the audio sync offset of
+ * @requestField inputAudioSyncOffset | Number(int64) | New audio sync offset in milliseconds | >= -950, <= 20000
  *
  * @requestType SetInputAudioSyncOffset
  * @complexity 3

--- a/src/requesthandler/RequestHandler_MediaInputs.cpp
+++ b/src/requesthandler/RequestHandler_MediaInputs.cpp
@@ -42,9 +42,9 @@ bool IsMediaTimeValid(obs_source_t *input)
  * @requestField ?inputName | String | Name of the media input
  * @requestField ?inputUuid | String | UUID of the media input
  *
- * @responseField mediaState    | String | State of the media input
- * @responseField mediaDuration | Number | Total duration of the playing media in milliseconds. `null` if not playing
- * @responseField mediaCursor   | Number | Position of the cursor in milliseconds. `null` if not playing
+ * @responseField mediaState    | String        | State of the media input
+ * @responseField mediaDuration | Number(int64) | Total duration of the playing media in milliseconds. `null` if not playing
+ * @responseField mediaCursor   | Number(int64) | Position of the cursor in milliseconds. `null` if not playing
  *
  * @requestType GetMediaInputStatus
  * @complexity 2
@@ -81,9 +81,9 @@ RequestResult RequestHandler::GetMediaInputStatus(const Request &request)
  *
  * This request does not perform bounds checking of the cursor position.
  *
- * @requestField ?inputName  | String | Name of the media input
- * @requestField ?inputUuid  | String | UUID of the media input
- * @requestField mediaCursor | Number | New cursor position to set | >= 0
+ * @requestField ?inputName  | String        | Name of the media input
+ * @requestField ?inputUuid  | String        | UUID of the media input
+ * @requestField mediaCursor | Number(int64) | New cursor position to set | >= 0
  *
  * @requestType SetMediaInputCursor
  * @complexity 2
@@ -117,9 +117,9 @@ RequestResult RequestHandler::SetMediaInputCursor(const Request &request)
  *
  * This request does not perform bounds checking of the cursor position.
  *
- * @requestField ?inputName        | String | Name of the media input
- * @requestField ?inputUuid        | String | UUID of the media input
- * @requestField mediaCursorOffset | Number | Value to offset the current cursor position by | None
+ * @requestField ?inputName        | String        | Name of the media input
+ * @requestField ?inputUuid        | String        | UUID of the media input
+ * @requestField mediaCursorOffset | Number(int64) | Value to offset the current cursor position by | None
  *
  * @requestType OffsetMediaInputCursor
  * @complexity 2

--- a/src/requesthandler/RequestHandler_Outputs.cpp
+++ b/src/requesthandler/RequestHandler_Outputs.cpp
@@ -297,14 +297,14 @@ RequestResult RequestHandler::GetOutputList(const Request &)
  *
  * @requestField outputName | String | Output name
  *
- * @responseField outputActive        | Boolean | Whether the output is active
- * @responseField outputReconnecting  | Boolean | Whether the output is reconnecting
- * @responseField outputTimecode      | String  | Current formatted timecode string for the output
- * @responseField outputDuration      | Number  | Current duration in milliseconds for the output
- * @responseField outputCongestion    | Number  | Congestion of the output
- * @responseField outputBytes         | Number  | Number of bytes sent by the output
- * @responseField outputSkippedFrames | Number  | Number of frames skipped by the output's process
- * @responseField outputTotalFrames   | Number  | Total number of frames delivered by the output's process
+ * @responseField outputActive        | Boolean        | Whether the output is active
+ * @responseField outputReconnecting  | Boolean        | Whether the output is reconnecting
+ * @responseField outputTimecode      | String         | Current formatted timecode string for the output
+ * @responseField outputDuration      | Number(uint64) | Current duration in milliseconds for the output
+ * @responseField outputCongestion    | Number(float)  | Congestion of the output
+ * @responseField outputBytes         | Number(uint64) | Number of bytes sent by the output
+ * @responseField outputSkippedFrames | Number(int32)  | Number of frames skipped by the output's process
+ * @responseField outputTotalFrames   | Number(int32)  | Total number of frames delivered by the output's process
  *
  * @requestType GetOutputStatus
  * @complexity 4

--- a/src/requesthandler/RequestHandler_Record.cpp
+++ b/src/requesthandler/RequestHandler_Record.cpp
@@ -22,11 +22,11 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 /**
  * Gets the status of the record output.
  *
- * @responseField outputActive        | Boolean | Whether the output is active
- * @responseField outputPaused        | Boolean | Whether the output is paused
- * @responseField outputTimecode      | String  | Current formatted timecode string for the output
- * @responseField outputDuration      | Number  | Current duration in milliseconds for the output
- * @responseField outputBytes         | Number  | Number of bytes sent by the output
+ * @responseField outputActive        | Boolean        | Whether the output is active
+ * @responseField outputPaused        | Boolean        | Whether the output is paused
+ * @responseField outputTimecode      | String         | Current formatted timecode string for the output
+ * @responseField outputDuration      | Number(uint64) | Current duration in milliseconds for the output
+ * @responseField outputBytes         | Number(uint64) | Number of bytes sent by the output
  *
  * @requestType GetRecordStatus
  * @complexity 2

--- a/src/requesthandler/RequestHandler_SceneItems.cpp
+++ b/src/requesthandler/RequestHandler_SceneItems.cpp
@@ -88,12 +88,12 @@ RequestResult RequestHandler::GetGroupSceneItemList(const Request &request)
  *
  * Scenes and Groups
  *
- * @requestField ?sceneName    | String | Name of the scene or group to search in
- * @requestField ?sceneUuid    | String | UUID of the scene or group to search in
- * @requestField sourceName    | String | Name of the source to find
- * @requestField ?searchOffset | Number | Number of matches to skip during search. >= 0 means first forward. -1 means last (top) item | >= -1 | 0
+ * @requestField ?sceneName    | String        | Name of the scene or group to search in
+ * @requestField ?sceneUuid    | String        | UUID of the scene or group to search in
+ * @requestField sourceName    | String        | Name of the source to find
+ * @requestField ?searchOffset | Number(int32) | Number of matches to skip during search. >= 0 means first forward. -1 means last (top) item | >= -1 | 0
  *
- * @responseField sceneItemId | Number | Numeric ID of the scene item
+ * @responseField sceneItemId | Number(int64) | Numeric ID of the scene item
  *
  * @requestType GetSceneItemId
  * @complexity 3
@@ -133,9 +133,9 @@ RequestResult RequestHandler::GetSceneItemId(const Request &request)
 /**
  * Gets the source associated with a scene item.
  *
- * @requestField ?sceneName  | String | Name of the scene the item is in
- * @requestField ?sceneUuid  | String | UUID of the scene the item is in
- * @requestField sceneItemId | Number | Numeric ID of the scene item | >= 0
+ * @requestField ?sceneName  | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid  | String        | UUID of the scene the item is in
+ * @requestField sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0
  *
  * @responseField sourceName | String | Name of the source associated with the scene item
  * @responseField sourceUuid | String | UUID of the source associated with the scene item
@@ -175,7 +175,7 @@ RequestResult RequestHandler::GetSceneItemSource(const Request &request)
  * @requestField ?sourceUuid       | String  | UUID of the source to add to the scene
  * @requestField ?sceneItemEnabled | Boolean | Enable state to apply to the scene item on creation | True
  *
- * @responseField sceneItemId | Number | Numeric ID of the scene item
+ * @responseField sceneItemId | Number(int64) | Numeric ID of the scene item
  *
  * @requestType CreateSceneItem
  * @complexity 3
@@ -223,9 +223,9 @@ RequestResult RequestHandler::CreateSceneItem(const Request &request)
  *
  * Scenes only
  *
- * @requestField ?sceneName  | String | Name of the scene the item is in
- * @requestField ?sceneUuid  | String | UUID of the scene the item is in
- * @requestField sceneItemId | Number | Numeric ID of the scene item | >= 0
+ * @requestField ?sceneName  | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid  | String        | UUID of the scene the item is in
+ * @requestField sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0
  *
  * @requestType RemoveSceneItem
  * @complexity 3
@@ -253,13 +253,13 @@ RequestResult RequestHandler::RemoveSceneItem(const Request &request)
  *
  * Scenes only
  *
- * @requestField ?sceneName            | String | Name of the scene the item is in
- * @requestField ?sceneUuid            | String | UUID of the scene the item is in
- * @requestField sceneItemId           | Number | Numeric ID of the scene item | >= 0
- * @requestField ?destinationSceneName | String | Name of the scene to create the duplicated item in | From scene is assumed
- * @requestField ?destinationSceneUuid | String | UUID of the scene to create the duplicated item in | From scene is assumed
+ * @requestField ?sceneName            | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid            | String        | UUID of the scene the item is in
+ * @requestField sceneItemId           | Number(int64) | Numeric ID of the scene item | >= 0
+ * @requestField ?destinationSceneName | String        | Name of the scene to create the duplicated item in | From scene is assumed
+ * @requestField ?destinationSceneUuid | String        | UUID of the scene to create the duplicated item in | From scene is assumed
  *
- * @responseField sceneItemId | Number | Numeric ID of the duplicated scene item
+ * @responseField sceneItemId | Number(int64) | Numeric ID of the duplicated scene item
  *
  * @requestType DuplicateSceneItem
  * @complexity 3
@@ -330,9 +330,9 @@ RequestResult RequestHandler::DuplicateSceneItem(const Request &request)
  *
  * Scenes and Groups
  *
- * @requestField ?sceneName  | String | Name of the scene the item is in
- * @requestField ?sceneUuid  | String | UUID of the scene the item is in
- * @requestField sceneItemId | Number | Numeric ID of the scene item | >= 0
+ * @requestField ?sceneName  | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid  | String        | UUID of the scene the item is in
+ * @requestField sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0
  *
  * @responseField sceneItemTransform | Object | Object containing scene item transform info
  *
@@ -361,10 +361,10 @@ RequestResult RequestHandler::GetSceneItemTransform(const Request &request)
 /**
  * Sets the transform and crop info of a scene item.
  *
- * @requestField ?sceneName         | String | Name of the scene the item is in
- * @requestField ?sceneUuid         | String | UUID of the scene the item is in
- * @requestField sceneItemId        | Number | Numeric ID of the scene item | >= 0
- * @requestField sceneItemTransform | Object | Object containing scene item transform info to update
+ * @requestField ?sceneName         | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid         | String        | UUID of the scene the item is in
+ * @requestField sceneItemId        | Number(int64) | Numeric ID of the scene item | >= 0
+ * @requestField sceneItemTransform | Object        | Object containing scene item transform info to update
  *
  * @requestType SetSceneItemTransform
  * @complexity 3
@@ -526,9 +526,9 @@ RequestResult RequestHandler::SetSceneItemTransform(const Request &request)
  *
  * Scenes and Groups
  *
- * @requestField ?sceneName  | String | Name of the scene the item is in
- * @requestField ?sceneUuid  | String | UUID of the scene the item is in
- * @requestField sceneItemId | Number | Numeric ID of the scene item | >= 0
+ * @requestField ?sceneName  | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid  | String        | UUID of the scene the item is in
+ * @requestField sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0
  *
  * @responseField sceneItemEnabled | Boolean | Whether the scene item is enabled. `true` for enabled, `false` for disabled
  *
@@ -559,10 +559,10 @@ RequestResult RequestHandler::GetSceneItemEnabled(const Request &request)
  *
  * Scenes and Groups
  *
- * @requestField ?sceneName       | String  | Name of the scene the item is in
- * @requestField ?sceneUuid       | String  | UUID of the scene the item is in
- * @requestField sceneItemId      | Number  | Numeric ID of the scene item | >= 0
- * @requestField sceneItemEnabled | Boolean | New enable state of the scene item
+ * @requestField ?sceneName       | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid       | String        | UUID of the scene the item is in
+ * @requestField sceneItemId      | Number(int64) | Numeric ID of the scene item | >= 0
+ * @requestField sceneItemEnabled | Boolean       | New enable state of the scene item
  *
  * @requestType SetSceneItemEnabled
  * @complexity 3
@@ -592,9 +592,9 @@ RequestResult RequestHandler::SetSceneItemEnabled(const Request &request)
  *
  * Scenes and Groups
  *
- * @requestField ?sceneName  | String | Name of the scene the item is in
- * @requestField ?sceneUuid  | String | UUID of the scene the item is in
- * @requestField sceneItemId | Number | Numeric ID of the scene item | >= 0
+ * @requestField ?sceneName  | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid  | String        | UUID of the scene the item is in
+ * @requestField sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0
  *
  * @responseField sceneItemLocked | Boolean | Whether the scene item is locked. `true` for locked, `false` for unlocked
  *
@@ -625,10 +625,10 @@ RequestResult RequestHandler::GetSceneItemLocked(const Request &request)
  *
  * Scenes and Group
  *
- * @requestField ?sceneName      | String  | Name of the scene the item is in
- * @requestField ?sceneUuid      | String  | UUID of the scene the item is in
- * @requestField sceneItemId     | Number  | Numeric ID of the scene item | >= 0
- * @requestField sceneItemLocked | Boolean | New lock state of the scene item
+ * @requestField ?sceneName      | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid      | String        | UUID of the scene the item is in
+ * @requestField sceneItemId     | Number(int64) | Numeric ID of the scene item | >= 0
+ * @requestField sceneItemLocked | Boolean       | New lock state of the scene item
  *
  * @requestType SetSceneItemLocked
  * @complexity 3
@@ -660,11 +660,11 @@ RequestResult RequestHandler::SetSceneItemLocked(const Request &request)
  *
  * Scenes and Groups
  *
- * @requestField ?sceneName  | String | Name of the scene the item is in
- * @requestField ?sceneUuid  | String | UUID of the scene the item is in
- * @requestField sceneItemId | Number | Numeric ID of the scene item | >= 0
+ * @requestField ?sceneName  | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid  | String        | UUID of the scene the item is in
+ * @requestField sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0
  *
- * @responseField sceneItemIndex | Number | Index position of the scene item
+ * @responseField sceneItemIndex | Number(int32) | Index position of the scene item
  *
  * @requestType GetSceneItemIndex
  * @complexity 3
@@ -693,10 +693,10 @@ RequestResult RequestHandler::GetSceneItemIndex(const Request &request)
  *
  * Scenes and Groups
  *
- * @requestField ?sceneName     | String | Name of the scene the item is in
- * @requestField ?sceneUuid     | String | UUID of the scene the item is in
- * @requestField sceneItemId    | Number | Numeric ID of the scene item         | >= 0
- * @requestField sceneItemIndex | Number | New index position of the scene item | >= 0
+ * @requestField ?sceneName     | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid     | String        | UUID of the scene the item is in
+ * @requestField sceneItemId    | Number(int64) | Numeric ID of the scene item         | >= 0
+ * @requestField sceneItemIndex | Number(int32) | New index position of the scene item | >= 0
  *
  * @requestType SetSceneItemIndex
  * @complexity 3
@@ -736,9 +736,9 @@ RequestResult RequestHandler::SetSceneItemIndex(const Request &request)
  *
  * Scenes and Groups
  *
- * @requestField ?sceneName  | String | Name of the scene the item is in
- * @requestField ?sceneUuid  | String | UUID of the scene the item is in
- * @requestField sceneItemId | Number | Numeric ID of the scene item | >= 0
+ * @requestField ?sceneName  | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid  | String        | UUID of the scene the item is in
+ * @requestField sceneItemId | Number(int64) | Numeric ID of the scene item | >= 0
  *
  * @responseField sceneItemBlendMode | String | Current blend mode
  *
@@ -771,10 +771,10 @@ RequestResult RequestHandler::GetSceneItemBlendMode(const Request &request)
  *
  * Scenes and Groups
  *
- * @requestField ?sceneName         | String | Name of the scene the item is in
- * @requestField ?sceneUuid         | String | UUID of the scene the item is in
- * @requestField sceneItemId        | Number | Numeric ID of the scene item | >= 0
- * @requestField sceneItemBlendMode | String | New blend mode
+ * @requestField ?sceneName         | String        | Name of the scene the item is in
+ * @requestField ?sceneUuid         | String        | UUID of the scene the item is in
+ * @requestField sceneItemId        | Number(int64) | Numeric ID of the scene item | >= 0
+ * @requestField sceneItemBlendMode | String        | New blend mode
  *
  * @requestType SetSceneItemBlendMode
  * @complexity 2

--- a/src/requesthandler/RequestHandler_Scenes.cpp
+++ b/src/requesthandler/RequestHandler_Scenes.cpp
@@ -311,8 +311,8 @@ RequestResult RequestHandler::SetSceneName(const Request &request)
  * @requestField ?sceneName | String | Name of the scene
  * @requestField ?sceneUuid | String | UUID of the scene
  *
- * @responseField transitionName     | String | Name of the overridden scene transition, else `null`
- * @responseField transitionDuration | Number | Duration of the overridden scene transition, else `null`
+ * @responseField transitionName     | String        | Name of the overridden scene transition, else `null`
+ * @responseField transitionDuration | Number(int64) | Duration of the overridden scene transition, else `null`
  *
  * @requestType GetSceneSceneTransitionOverride
  * @complexity 2
@@ -349,10 +349,10 @@ RequestResult RequestHandler::GetSceneSceneTransitionOverride(const Request &req
 /**
  * Sets the scene transition overridden for a scene.
  *
- * @requestField ?sceneName          | String | Name of the scene
- * @requestField ?sceneUuid          | String | UUID of the scene
- * @requestField ?transitionName     | String | Name of the scene transition to use as override. Specify `null` to remove | Unchanged
- * @requestField ?transitionDuration | Number | Duration to use for any overridden transition. Specify `null` to remove | >= 50, <= 20000 | Unchanged
+ * @requestField ?sceneName          | String        | Name of the scene
+ * @requestField ?sceneUuid          | String        | UUID of the scene
+ * @requestField ?transitionName     | String        | Name of the scene transition to use as override. Specify `null` to remove | Unchanged
+ * @requestField ?transitionDuration | Number(int64) | Duration to use for any overridden transition. Specify `null` to remove | >= 50, <= 20000 | Unchanged
  *
  * @requestType SetSceneSceneTransitionOverride
  * @complexity 2

--- a/src/requesthandler/RequestHandler_Sources.cpp
+++ b/src/requesthandler/RequestHandler_Sources.cpp
@@ -152,12 +152,12 @@ RequestResult RequestHandler::GetSourceActive(const Request &request)
  *
  * **Compatible with inputs and scenes.**
  *
- * @requestField ?sourceName              | String | Name of the source to take a screenshot of
- * @requestField ?sourceUuid              | String | UUID of the source to take a screenshot of
- * @requestField imageFormat              | String | Image compression format to use. Use `GetVersion` to get compatible image formats
- * @requestField ?imageWidth              | Number | Width to scale the screenshot to                                                                                         | >= 8, <= 4096 | Source value is used
- * @requestField ?imageHeight             | Number | Height to scale the screenshot to                                                                                        | >= 8, <= 4096 | Source value is used
- * @requestField ?imageCompressionQuality | Number | Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk) | >= -1, <= 100 | -1
+ * @requestField ?sourceName              | String         | Name of the source to take a screenshot of
+ * @requestField ?sourceUuid              | String         | UUID of the source to take a screenshot of
+ * @requestField imageFormat              | String         | Image compression format to use. Use `GetVersion` to get compatible image formats
+ * @requestField ?imageWidth              | Number(uint32) | Width to scale the screenshot to                                                                                         | >= 8, <= 4096 | Source value is used
+ * @requestField ?imageHeight             | Number(uint32) | Height to scale the screenshot to                                                                                        | >= 8, <= 4096 | Source value is used
+ * @requestField ?imageCompressionQuality | Number(int32)  | Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk) | >= -1, <= 100 | -1
  *
  * @responseField imageData | String | Base64-encoded screenshot
  *
@@ -240,13 +240,13 @@ RequestResult RequestHandler::GetSourceScreenshot(const Request &request)
  *
  * **Compatible with inputs and scenes.**
  *
- * @requestField ?sourceName              | String | Name of the source to take a screenshot of
- * @requestField ?sourceUuid              | String | UUID of the source to take a screenshot of
- * @requestField imageFormat              | String | Image compression format to use. Use `GetVersion` to get compatible image formats
- * @requestField imageFilePath            | String | Path to save the screenshot file to. Eg. `C:\Users\user\Desktop\screenshot.png`
- * @requestField ?imageWidth              | Number | Width to scale the screenshot to                                                                                         | >= 8, <= 4096 | Source value is used
- * @requestField ?imageHeight             | Number | Height to scale the screenshot to                                                                                        | >= 8, <= 4096 | Source value is used
- * @requestField ?imageCompressionQuality | Number | Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk) | >= -1, <= 100 | -1
+ * @requestField ?sourceName              | String         | Name of the source to take a screenshot of
+ * @requestField ?sourceUuid              | String         | UUID of the source to take a screenshot of
+ * @requestField imageFormat              | String         | Image compression format to use. Use `GetVersion` to get compatible image formats
+ * @requestField imageFilePath            | String         | Path to save the screenshot file to. Eg. `C:\Users\user\Desktop\screenshot.png`
+ * @requestField ?imageWidth              | Number(uint32) | Width to scale the screenshot to                                                                                         | >= 8, <= 4096 | Source value is used
+ * @requestField ?imageHeight             | Number(uint32) | Height to scale the screenshot to                                                                                        | >= 8, <= 4096 | Source value is used
+ * @requestField ?imageCompressionQuality | Number(int32)  | Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that means, idk) | >= -1, <= 100 | -1
  *
  * @requestType SaveSourceScreenshot
  * @complexity 3

--- a/src/requesthandler/RequestHandler_Stream.cpp
+++ b/src/requesthandler/RequestHandler_Stream.cpp
@@ -25,11 +25,11 @@ with this program. If not, see <https://www.gnu.org/licenses/>
  * @responseField outputActive        | Boolean | Whether the output is active
  * @responseField outputReconnecting  | Boolean | Whether the output is currently reconnecting
  * @responseField outputTimecode      | String  | Current formatted timecode string for the output
- * @responseField outputDuration      | Number  | Current duration in milliseconds for the output
- * @responseField outputCongestion    | Number  | Congestion of the output
- * @responseField outputBytes         | Number  | Number of bytes sent by the output
- * @responseField outputSkippedFrames | Number  | Number of frames skipped by the output's process
- * @responseField outputTotalFrames   | Number  | Total number of frames delivered by the output's process
+ * @responseField outputDuration      | Number(uint64) | Current duration in milliseconds for the output
+ * @responseField outputCongestion    | Number(float)  | Congestion of the output
+ * @responseField outputBytes         | Number(uint64) | Number of bytes sent by the output
+ * @responseField outputSkippedFrames | Number(int32)  | Number of frames skipped by the output's process
+ * @responseField outputTotalFrames   | Number(int32)  | Total number of frames delivered by the output's process
  *
  * @requestType GetStreamStatus
  * @complexity 2

--- a/src/requesthandler/RequestHandler_Transitions.cpp
+++ b/src/requesthandler/RequestHandler_Transitions.cpp
@@ -162,7 +162,7 @@ RequestResult RequestHandler::SetCurrentSceneTransition(const Request &request)
 /**
  * Sets the duration of the current scene transition, if it is not fixed.
  *
- * @requestField transitionDuration | Number | Duration in milliseconds | >= 50, <= 20000
+ * @requestField transitionDuration | Number(int32) | Duration in milliseconds | >= 50, <= 20000
  *
  * @requestType SetCurrentSceneTransitionDuration
  * @complexity 2
@@ -242,7 +242,7 @@ RequestResult RequestHandler::SetCurrentSceneTransitionSettings(const Request &r
  *
  * Note: `transitionCursor` will return 1.0 when the transition is inactive.
  *
- * @responseField transitionCursor | Number | Cursor position, between 0.0 and 1.0
+ * @responseField transitionCursor | Number(float) | Cursor position, between 0.0 and 1.0
  *
  * @requestType GetCurrentSceneTransitionCursor
  * @complexity 2

--- a/src/requesthandler/RequestHandler_Transitions.cpp
+++ b/src/requesthandler/RequestHandler_Transitions.cpp
@@ -80,13 +80,13 @@ RequestResult RequestHandler::GetSceneTransitionList(const Request &)
 /**
  * Gets information about the current scene transition.
  *
- * @responseField transitionName         | String  | Name of the transition
- * @responseField transitionUuid         | String  | UUID of the transition
- * @responseField transitionKind         | String  | Kind of the transition
- * @responseField transitionFixed        | Boolean | Whether the transition uses a fixed (unconfigurable) duration
- * @responseField transitionDuration     | Number  | Configured transition duration in milliseconds. `null` if transition is fixed
- * @responseField transitionConfigurable | Boolean | Whether the transition supports being configured
- * @responseField transitionSettings     | Object  | Object of settings for the transition. `null` if transition is not configurable
+ * @responseField transitionName         | String        | Name of the transition
+ * @responseField transitionUuid         | String        | UUID of the transition
+ * @responseField transitionKind         | String        | Kind of the transition
+ * @responseField transitionFixed        | Boolean       | Whether the transition uses a fixed (unconfigurable) duration
+ * @responseField transitionDuration     | Number(int32) | Configured transition duration in milliseconds. `null` if transition is fixed
+ * @responseField transitionConfigurable | Boolean       | Whether the transition supports being configured
+ * @responseField transitionSettings     | Object        | Object of settings for the transition. `null` if transition is not configurable
  *
  * @requestType GetCurrentSceneTransition
  * @complexity 2
@@ -291,8 +291,8 @@ RequestResult RequestHandler::TriggerStudioModeTransition(const Request &)
  *
  * **Very important note**: This will be deprecated and replaced in a future version of obs-websocket.
  *
- * @requestField position | Number  | New position | >= 0.0, <= 1.0
- * @requestField ?release | Boolean | Whether to release the TBar. Only set `false` if you know that you will be sending another position update | `true`
+ * @requestField position | Number(float) | New position | >= 0.0, <= 1.0
+ * @requestField ?release | Boolean       | Whether to release the TBar. Only set `false` if you know that you will be sending another position update | `true`
  *
  * @requestType SetTBarPosition
  * @complexity 3

--- a/src/requesthandler/RequestHandler_Ui.cpp
+++ b/src/requesthandler/RequestHandler_Ui.cpp
@@ -208,9 +208,9 @@ RequestResult RequestHandler::GetMonitorList(const Request &)
  *
  * Note: This request serves to provide feature parity with 4.x. It is very likely to be changed/deprecated in a future release.
  *
- * @requestField videoMixType            | String | Type of mix to open
- * @requestField ?monitorIndex      | Number | Monitor index, use `GetMonitorList` to obtain index | None | -1: Opens projector in windowed mode
- * @requestField ?projectorGeometry | String | Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex` | N/A
+ * @requestField videoMixType       | String        | Type of mix to open
+ * @requestField ?monitorIndex      | Number(int32) | Monitor index, use `GetMonitorList` to obtain index | None | -1: Opens projector in windowed mode
+ * @requestField ?projectorGeometry | String        | Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex` | N/A
  *
  * @requestType OpenVideoMixProjector
  * @complexity 3
@@ -265,10 +265,10 @@ RequestResult RequestHandler::OpenVideoMixProjector(const Request &request)
  *
  * Note: This request serves to provide feature parity with 4.x. It is very likely to be changed/deprecated in a future release.
  *
- * @requestField ?sourceName        | String | Name of the source to open a projector for
- * @requestField ?sourceUuid        | String | UUID of the source to open a projector for
- * @requestField ?monitorIndex      | Number | Monitor index, use `GetMonitorList` to obtain index | None | -1: Opens projector in windowed mode
- * @requestField ?projectorGeometry | String | Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex` | N/A
+ * @requestField ?sourceName        | String        | Name of the source to open a projector for
+ * @requestField ?sourceUuid        | String        | UUID of the source to open a projector for
+ * @requestField ?monitorIndex      | Number(int32) | Monitor index, use `GetMonitorList` to obtain index | None | -1: Opens projector in windowed mode
+ * @requestField ?projectorGeometry | String        | Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with `monitorIndex` | N/A
  *
  * @requestType OpenSourceProjector
  * @complexity 3


### PR DESCRIPTION
### Description
Add specific types of `number`

### Motivation and Context
I found that there were no specific numeric types when writing the [SDK](https://github.com/Coloryr/ObsWebSocketSharp), so I checked the code and added them.

### How Has This Been Tested?
Not need test.

### Types of changes

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [ ] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
