### PR TITLE
SettingsDialog: Fix Qt 6.7 checkbox signal deprecations

### DIFF
--- a/src/forms/SettingsDialog.cpp
+++ b/src/forms/SettingsDialog.cpp
@@ -56,8 +56,13 @@ SettingsDialog::SettingsDialog(QWidget *parent)
 
 	connect(sessionTableTimer, &QTimer::timeout, this, &SettingsDialog::FillSessionTable);
 	connect(ui->buttonBox, &QDialogButtonBox::clicked, this, &SettingsDialog::DialogButtonClicked);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+	connect(ui->enableAuthenticationCheckBox, &QCheckBox::checkStateChanged, this,
+		&SettingsDialog::EnableAuthenticationCheckBoxChanged);
+#else
 	connect(ui->enableAuthenticationCheckBox, &QCheckBox::stateChanged, this,
 		&SettingsDialog::EnableAuthenticationCheckBoxChanged);
+#endif
 	connect(ui->generatePasswordButton, &QPushButton::clicked, this, &SettingsDialog::GeneratePasswordButtonClicked);
 	connect(ui->showConnectInfoButton, &QPushButton::clicked, this, &SettingsDialog::ShowConnectInfoButtonClicked);
 	connect(ui->serverPasswordLineEdit, &QLineEdit::textEdited, this, &SettingsDialog::PasswordEdited);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
qt/qtbase@3512fb1ec5ff088772170540c4e91b1886fbea45 (also cherry-picked to https://github.com/qt/qtbase/commit/02ba4b14dc1c0cee802d8d840315833fda2449b4) deprecated the stateChanged signal of QCheckBoxes in favor of a new checkStateChanged signal. The signals are the same, except that now the enum type is passed explicitly (before the enum was passed as an argument but defined as an int).

The documentation states that it's deprecated for 6.9 but I got the warning now already (dev version appears to be 6.8 currently) and it's also picked to 6.7 and the alternative exists since 6.7 so I'm not 100% what the "real" deprecation version is but 6.7 makes sense.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Got a deprecation warning when compiling against Qt dev branch.

See:
* https://github.com/obsproject/obs-studio/pull/10732

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s):
* Windows 11: Built and ran against Qt 6.8.0-beta4

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
- Other Enhancement (anything not applicable to what is listed)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
