### PR TITLE
fix failing build

### DIFF
--- a/src/utils/Json.cpp
+++ b/src/utils/Json.cpp
@@ -18,6 +18,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
 #include <fstream>
+#include <filestream>
 
 #include "Json.h"
 #include "plugin-macros.generated.h"


### PR DESCRIPTION
### Description
current code in master fails to build because `Json.cpp` uses `std::filesystem` without including `<filesystem>`

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
-  [X] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [X] All commit messages are properly formatted and commits squashed where appropriate.
-  [X] My code is not on `master` or a `release/*` branch.
-  [X] The code has been tested.
