### PR TITLE
doc: fix broken link to README.md in protocol.md

### DIFF
--- a/docs/generated/protocol.md
+++ b/docs/generated/protocol.md
@@ -103,7 +103,7 @@ To generate the authentication string, follow these steps:
 - Concatenate the base64 secret with the `challenge` sent by the server (`base64_secret + challenge`)
 - Generate a binary SHA256 hash of that result and base64 encode it. You now have your `authentication` string.
 
-For real-world examples of the `authentication` string creation, refer to the obs-websocket client libraries listed on the [README](README.md).
+For real-world examples of the `authentication` string creation, refer to the obs-websocket client libraries listed on the [README](../../README.md).
 
 ## Message Types (OpCodes)
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
Originally it links to 404, now it links back to root README.md as the client library list there.

### Motivation and Context
N/A

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s):  N/A

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
Documentation change (a change to documentation pages)
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
