### PR TITLE
Fix profile functions that direct call a method instead of the API

### DIFF
--- a/src/requesthandler/RequestHandler_Config.cpp
+++ b/src/requesthandler/RequestHandler_Config.cpp
@@ -290,7 +290,7 @@ RequestResult RequestHandler::CreateProfile(const Request &request)
 		return RequestResult::Error(RequestStatus::ResourceAlreadyExists);
 
 	QMainWindow *mainWindow = static_cast<QMainWindow *>(obs_frontend_get_main_window());
-	QMetaObject::invokeMethod(mainWindow, "NewProfile", Qt::BlockingQueuedConnection,
+	QMetaObject::invokeMethod(mainWindow, "CreateNewProfile", Qt::BlockingQueuedConnection,
 				  Q_ARG(QString, QString::fromStdString(profileName)));
 
 	return RequestResult::Success();

--- a/src/requesthandler/RequestHandler_Config.cpp
+++ b/src/requesthandler/RequestHandler_Config.cpp
@@ -289,7 +289,7 @@ RequestResult RequestHandler::CreateProfile(const Request &request)
 	if (std::find(profiles.begin(), profiles.end(), profileName) != profiles.end())
 		return RequestResult::Error(RequestStatus::ResourceAlreadyExists);
 
-	obs_frontend_create_profile(profileName);
+	obs_frontend_create_profile(profileName.c_str());
 
 	return RequestResult::Success();
 }
@@ -322,7 +322,7 @@ RequestResult RequestHandler::RemoveProfile(const Request &request)
 	if (profiles.size() < 2)
 		return RequestResult::Error(RequestStatus::NotEnoughResources);
 
-	obs_frontend_delete_profile(profileName);
+	obs_frontend_delete_profile(profileName.c_str());
 
 	return RequestResult::Success();
 }

--- a/src/requesthandler/RequestHandler_Config.cpp
+++ b/src/requesthandler/RequestHandler_Config.cpp
@@ -289,7 +289,7 @@ RequestResult RequestHandler::CreateProfile(const Request &request)
 	if (std::find(profiles.begin(), profiles.end(), profileName) != profiles.end())
 		return RequestResult::Error(RequestStatus::ResourceAlreadyExists);
 
-	obs_frontend_create_profile(QString::fromStdString(profileName));
+	obs_frontend_create_profile(profileName);
 
 	return RequestResult::Success();
 }
@@ -322,7 +322,7 @@ RequestResult RequestHandler::RemoveProfile(const Request &request)
 	if (profiles.size() < 2)
 		return RequestResult::Error(RequestStatus::NotEnoughResources);
 
-	obs_frontend_delete_profile(QString::fromStdString(profileName));
+	obs_frontend_delete_profile(profileName);
 
 	return RequestResult::Success();
 }

--- a/src/requesthandler/RequestHandler_Config.cpp
+++ b/src/requesthandler/RequestHandler_Config.cpp
@@ -289,9 +289,7 @@ RequestResult RequestHandler::CreateProfile(const Request &request)
 	if (std::find(profiles.begin(), profiles.end(), profileName) != profiles.end())
 		return RequestResult::Error(RequestStatus::ResourceAlreadyExists);
 
-	QMainWindow *mainWindow = static_cast<QMainWindow *>(obs_frontend_get_main_window());
-	QMetaObject::invokeMethod(mainWindow, "CreateNewProfile", Qt::BlockingQueuedConnection,
-				  Q_ARG(QString, QString::fromStdString(profileName)));
+	obs_frontend_create_profile(QString::fromStdString(profileName));
 
 	return RequestResult::Success();
 }
@@ -324,9 +322,7 @@ RequestResult RequestHandler::RemoveProfile(const Request &request)
 	if (profiles.size() < 2)
 		return RequestResult::Error(RequestStatus::NotEnoughResources);
 
-	QMainWindow *mainWindow = static_cast<QMainWindow *>(obs_frontend_get_main_window());
-	QMetaObject::invokeMethod(mainWindow, "DeleteProfile", Qt::BlockingQueuedConnection,
-				  Q_ARG(QString, QString::fromStdString(profileName)));
+	obs_frontend_delete_profile(QString::fromStdString(profileName));
 
 	return RequestResult::Success();
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->

Fixes #1264 

~~This just updates the function name invoked to the new one outlined in https://github.com/obsproject/obs-studio/commit/b9808eaca82340132c56e1577ae58a1e8747a119~~

~~Conceptually to prevent this fault in future should move to `obs_frontend_create_profile` instead?~~

Move create and delete profile to their API functions instead

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

WebSocket function for `CreateProfile` is not working in 31 beta due to internal function rename and not using an API function

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [ ] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
