### PR TITLE
utils: Use u8path to fix possible string conversion crashes on Windows

### DIFF
--- a/src/utils/Json.cpp
+++ b/src/utils/Json.cpp
@@ -178,7 +178,7 @@ json Utils::Json::ObsDataToJson(obs_data_t *d, bool includeDefault)
 
 bool Utils::Json::GetJsonFileContent(std::string fileName, json &content)
 {
-	std::ifstream f(fileName);
+	std::ifstream f(std::filesystem::u8path(fileName));
 	if (!f.is_open())
 		return false;
 
@@ -195,9 +195,11 @@ bool Utils::Json::GetJsonFileContent(std::string fileName, json &content)
 
 bool Utils::Json::SetJsonFileContent(std::string fileName, const json &content, bool makeDirs)
 {
+	auto jsonFilePath = std::filesystem::u8path(fileName);
+
 	if (makeDirs) {
+		auto p = jsonFilePath.parent_path();
 		std::error_code ec;
-		auto p = std::filesystem::path(fileName).parent_path();
 		if (!ec && !std::filesystem::exists(p, ec))
 			std::filesystem::create_directories(p, ec);
 		if (ec) {
@@ -207,7 +209,7 @@ bool Utils::Json::SetJsonFileContent(std::string fileName, const json &content, 
 		}
 	}
 
-	std::ofstream f(fileName);
+	std::ofstream f(jsonFilePath);
 	if (!f.is_open()) {
 		blog(LOG_ERROR, "[Utils::Json::SetJsonFileContent] Failed to open file `%s` for writing", fileName.c_str());
 		return false;


### PR DESCRIPTION
### Description
Use `u8path` when creating a file system path via a provided `std::string`.

### Motivation and Context
All other path operations in the code base already use u8path to ensure that the strings provided by libobs (which will either be ASCII or UTF-8 byte sequences) are correctly converted into UTF-16 strings.

Fixes #1244.

### How Has This Been Tested?
Has not been tested locally, will need simple reproducer first.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [ ] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
