### PR TITLE
eventhandler: Fix possible crash on OBS start in Studio Mode

### DIFF
--- a/src/eventhandler/EventHandler_Scenes.cpp
+++ b/src/eventhandler/EventHandler_Scenes.cpp
@@ -109,6 +109,9 @@ void EventHandler::HandleCurrentProgramSceneChanged()
 {
 	OBSSourceAutoRelease currentScene = obs_frontend_get_current_scene();
 
+	if (!currentScene)
+		return;
+
 	json eventData;
 	eventData["sceneName"] = obs_source_get_name(currentScene);
 	eventData["sceneUuid"] = obs_source_get_uuid(currentScene);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->

When OBS Studio is started in Studio Mode, if a scene collection was not successfully found and loaded, the OBS Frontend API would, prior to https://github.com/obsproject/obs-studio/commit/577e3504d59f0d8e488ada7a05295d1d8267f095, emit OBS_FRONTEND_EVENT_SCENE_CHANGED and
OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED anyway. This would result in currentScene here being a nullptr, causing a crash.

For completeness, check for nullptr here so that we cannot crash if obs_frontend_get_current_scene() returns a nullptr.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->

https://github.com/obsproject/obs-studio/pull/11897
https://github.com/obsproject/obs-studio/commit/577e3504d59f0d8e488ada7a05295d1d8267f095

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): 

I haven't personally tested this, but this change was discussed while reviewing https://github.com/obsproject/obs-studio/pull/11897.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [ ] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
