### PR TITLE
base: Apply latest clang-format changes from upstream

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -81,6 +81,7 @@ PenaltyReturnTypeOnItsOwnLine: 60
 
 PointerAlignment: Right
 ReflowComments: false
+SkipMacroDefinitionBody: true
 SortIncludes: false
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false

--- a/src/requesthandler/RequestHandler_Inputs.cpp
+++ b/src/requesthandler/RequestHandler_Inputs.cpp
@@ -940,8 +940,10 @@ RequestResult RequestHandler::SetInputDeinterlaceMode(const Request &request)
 		return RequestResult::Error(RequestStatus::InvalidResourceState, "The specified input is not async.");
 
 	enum obs_deinterlace_mode deinterlaceMode = request.RequestData["inputDeinterlaceMode"];
-	if (deinterlaceMode == OBS_DEINTERLACE_MODE_DISABLE && request.RequestData["inputDeinterlaceMode"] != "OBS_DEINTERLACE_MODE_DISABLE")
-		return RequestResult::Error(RequestStatus::InvalidRequestField, "The field inputDeinterlaceMode has an invalid value.");
+	if (deinterlaceMode == OBS_DEINTERLACE_MODE_DISABLE &&
+	    request.RequestData["inputDeinterlaceMode"] != "OBS_DEINTERLACE_MODE_DISABLE")
+		return RequestResult::Error(RequestStatus::InvalidRequestField,
+					    "The field inputDeinterlaceMode has an invalid value.");
 
 	obs_source_set_deinterlace_mode(input, deinterlaceMode);
 
@@ -1015,8 +1017,10 @@ RequestResult RequestHandler::SetInputDeinterlaceFieldOrder(const Request &reque
 		return RequestResult::Error(RequestStatus::InvalidResourceState, "The specified input is not async.");
 
 	enum obs_deinterlace_field_order deinterlaceFieldOrder = request.RequestData["inputDeinterlaceFieldOrder"];
-	if (deinterlaceFieldOrder == OBS_DEINTERLACE_FIELD_ORDER_TOP && request.RequestData["inputDeinterlaceFieldOrder"] != "OBS_DEINTERLACE_FIELD_ORDER_TOP")
-		return RequestResult::Error(RequestStatus::InvalidRequestField, "The field inputDeinterlaceFieldOrder has an invalid value.");
+	if (deinterlaceFieldOrder == OBS_DEINTERLACE_FIELD_ORDER_TOP &&
+	    request.RequestData["inputDeinterlaceFieldOrder"] != "OBS_DEINTERLACE_FIELD_ORDER_TOP")
+		return RequestResult::Error(RequestStatus::InvalidRequestField,
+					    "The field inputDeinterlaceFieldOrder has an invalid value.");
 
 	obs_source_set_deinterlace_field_order(input, deinterlaceFieldOrder);
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
This changes the formatting for the repository to clang-format 19.1.1, same as upstream obs-studio.
New changes to .clang-format from obs-studio are brought over (see obsproject/obs-studio@b3ab79291659dd40f6eeab016a62b742a9acff99), but the submodule-specific modifications are left in place (see 5fc39ef054db4a5976b903921fb8965c100ee31e).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Got formatting changes when doing `./build-aux/run-clang-format` on obs-studio, which is annoying.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Running `./build-aux/run-clang-format` on obs-studio no longer produces any changes. Still compiles.
This repo doesn't have any formatting check, so there is no CI to test.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
