### PR TITLE
Config: Use app_config instead of global_config for migration

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -155,7 +155,7 @@ void Config::Save()
 json MigrateGlobalConfigData()
 {
 	// Get existing global config
-	config_t *config = obs_frontend_get_global_config();
+	config_t *config = obs_frontend_get_app_config();
 	json ret;
 
 	// Move values to temporary JSON blob


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines -->

### Description
<!--- Describe your changes. -->
The data that should be migrated used to be in global.ini. Since the frontend migration, it would be copied to both app and user config, we can just use the app config here.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes an open issue or implements feature request, -->
<!--- please link to the issue here. -->
Fix the `obs_frontend_get_global_config` deprecation warning.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes, along with the OS(s) you tested with. -->
Tested OS(s): macOS 26
Put a value for `ServerPassword` in the `OBSWebSocket` section in `global.ini`, and that change was migrated successfully.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - New request/event (non-breaking) -->
<!--- - Documentation change (a change to documentation pages) -->
<!--- - Other Enhancement (anything not applicable to what is listed) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  [x] I have read the [Contributing Guidelines](https://github.com/obsproject/obs-websocket/wiki/Contributing-Guidelines).
-  [x] All commit messages are properly formatted and commits squashed where appropriate.
-  [x] My code is not on `master` or a `release/*` branch.
-  [x] The code has been tested.
-  [x] I have included updates to all appropriate documentation.
